### PR TITLE
Subfolder routing

### DIFF
--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -4,7 +4,8 @@ from django.http import Http404
 from django.urls import set_urlconf
 from django.utils.deprecation import MiddlewareMixin
 
-from django_tenants.utils import remove_www, get_public_schema_name, get_tenant_domain_model
+from django_tenants.utils import remove_www, get_public_schema_name, get_tenant_model, get_tenant_domain_model
+from django_tenants.urlresolvers import subfolder_matcher, subfolder_dynamic_urlconf
 
 
 class TenantMainMiddleware(MiddlewareMixin):
@@ -32,18 +33,33 @@ class TenantMainMiddleware(MiddlewareMixin):
         connection.set_schema_to_public()
         hostname = self.hostname_from_request(request)
 
+        tenant_model = get_tenant_model()
         domain_model = get_tenant_domain_model()
         try:
             tenant = self.get_tenant(domain_model, hostname)
         except domain_model.DoesNotExist:
             raise self.TENANT_NOT_FOUND_EXCEPTION('No tenant for hostname "%s"' % hostname)
 
+        if tenant.schema_name == get_public_schema_name():
+            subfolder_match = subfolder_matcher.match(request.path)
+
+            # Are we in a subfolder routing?
+            if subfolder_match:
+                subfolder = subfolder_match["schema_name"]
+                try:
+                    tenant = tenant_model.objects.get(schema_name=subfolder)
+                except tenant_model.DoesNotExist:
+                    raise self.TENANT_NOT_FOUND_EXCEPTION('No tenant for subfolder "%s"' % subfolder)
+
+                request.urlconf = subfolder_dynamic_urlconf(tenant)
+                set_urlconf(request.urlconf)
+
+            # Do we have a public-specific urlconf?
+            elif hasattr(settings, 'PUBLIC_SCHEMA_URLCONF'):
+                request.urlconf = settings.PUBLIC_SCHEMA_URLCONF
+                set_urlconf(request.urlconf)
+
         tenant.domain_url = hostname
         request.tenant = tenant
 
         connection.set_tenant(request.tenant)
-
-        # Do we have a public-specific urlconf?
-        if hasattr(settings, 'PUBLIC_SCHEMA_URLCONF') and request.tenant.schema_name == get_public_schema_name():
-            request.urlconf = settings.PUBLIC_SCHEMA_URLCONF
-            set_urlconf(request.urlconf)

--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -21,7 +21,8 @@ original_backend = import_module(ORIGINAL_BACKEND + '.base')
 EXTRA_SEARCH_PATHS = getattr(settings, 'PG_EXTRA_SEARCH_PATHS', [])
 
 # from the postgresql doc
-SQL_IDENTIFIER_RE = re.compile(r'^[_a-zA-Z0-9]{1,63}$')
+SQL_IDENTIFIER = r'^[_a-zA-Z0-9]{1,63}$'
+SQL_IDENTIFIER_RE = re.compile(SQL_IDENTIFIER)
 SQL_SCHEMA_NAME_RESERVED_RE = re.compile(r'^pg_', re.IGNORECASE)
 
 

--- a/django_tenants/urlresolvers.py
+++ b/django_tenants/urlresolvers.py
@@ -1,6 +1,17 @@
-from django.urls import reverse as reverse_default
-from django.utils.functional import lazy
+import re
+import sys
+
 from django_tenants.utils import clean_tenant_url
+from django.conf import settings
+from django.db import connection
+from django.urls import reverse as reverse_default
+from django.urls import URLResolver
+from django.utils.functional import lazy
+from django.utils.module_loading import import_string
+from importlib.util import find_spec, module_from_spec
+
+from .utils import get_tenant_model
+from .postgresql_backend.base import SQL_IDENTIFIER
 
 
 def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
@@ -9,3 +20,64 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, current_app=None):
 
 
 reverse_lazy = lazy(reverse, str)
+
+
+SUBFOLDER_PREFIX = getattr(settings, "SUBFOLDER_PREFIX", "..")
+subfolder_matcher = re.compile(
+    r"^/" + SUBFOLDER_PREFIX + r"/(?P<schema_name>" + SQL_IDENTIFIER[1:-1] + r")/"
+)
+
+
+class TenantPrefixPattern:
+    converters = {}
+
+    @property
+    def tenant_prefix(self):
+        TenantModel = get_tenant_model()
+        try:
+            tenant = TenantModel.objects.get(schema_name=connection.schema_name)
+            return "{}/{}/".format(SUBFOLDER_PREFIX, tenant.schema_name)
+        except TenantModel.DoesNotExist:
+            return "/"
+
+    @property
+    def regex(self):
+        # This is only used by reverse() and cached in _reverse_dict.
+        return re.compile(self.tenant_prefix)
+
+    def match(self, path):
+        tenant_prefix = self.tenant_prefix
+        if path.startswith(tenant_prefix):
+            return path[len(tenant_prefix) :], (), {}
+        return None
+
+    def check(self):
+        return []
+
+    def describe(self):
+        return "'{}'".format(self)
+
+    def __str__(self):
+        return self.tenant_prefix
+
+
+def tenant_patterns(*urls):
+    """
+    Add the tenant prefix to every URL pattern within this function.
+    This may only be used in the root URLconf, not in an included URLconf.
+    """
+    return [URLResolver(TenantPrefixPattern(), list(urls))]
+
+
+def subfolder_dynamic_urlconf(tenant):
+    urlconf = settings.ROOT_URLCONF + "_dynamically_tenant_prefixed"
+    if not sys.modules.get(urlconf):
+        spec = find_spec(settings.ROOT_URLCONF)
+        prefixed_url_module = module_from_spec(spec)
+        spec.loader.exec_module(prefixed_url_module)
+        prefixed_url_module.urlpatterns = tenant_patterns(
+            *import_string(settings.ROOT_URLCONF + ".urlpatterns")
+        )
+        sys.modules[urlconf] = prefixed_url_module
+        del spec
+    return urlconf

--- a/dts_test_project/dts_test_project/settings.py
+++ b/dts_test_project/dts_test_project/settings.py
@@ -75,6 +75,7 @@ ROOT_URLCONF = 'dts_test_project.urls'
 
 WSGI_APPLICATION = 'dts_test_project.wsgi.application'
 
+SUBFOLDER_PREFIX = 'clients'
 
 # Database
 # https://docs.djangoproject.com/en/1.6/ref/settings/#databases


### PR DESCRIPTION
Coarse proof of concept of the mechanism I am using in https://github.com/lorinkoz/django-pgschemas

Something like this could become the solution for issues like #183, #28

Some comments:
- Here I'm using the `schema_name` as identifier for subfolder matching. In `pgschemas` I extended the domain model to become a pair of `(domain, folder)`, so that fine grained routing could be achieved.
- In `pgschemas` I have reports from a user that this method for dynamic urlconf construction fails when using certain 3rd party libraries that do custom handling of URLs (this would be up to testing on real life projects that might contain those). Another variant with less dark magic would be something I saw on #28 in a code example from @owais, the drawback of that solution would be that a new module will be created on the fly for each tenant, but not sure if that would even be a problem per-se.
- In `pgschemas` I had to use `django.urls.clear_url_caches` in order to refresh from the previous matched subfolder tenant, ~maybe it's not needed here because this project is using `set_urlconf`~(I will add this here soon). To be aware, the symptom of this problem is that after successfully visiting tenant A through subfolders, reversed urls for tenant B are returned with the tenant A instead. (see https://github.com/lorinkoz/django-pgschemas/blob/master/django_pgschemas/middleware.py#L57)
- Tests are failing on Python 3.8 (#335)
- If this proof of concept is okay, I can work in adding tests.