### PR TITLE
TenantMixin: Allow mixin to be used with `with ... as` statement

### DIFF
--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -56,6 +56,8 @@ class TenantMixin(models.Model):
         self._previous_tenant.append(connection.tenant)
         self.activate()
 
+        return self
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         connection = connections[get_tenant_database_alias()]
 


### PR DESCRIPTION
Related to #440. The docstring states that the intention is to use `TenantMixin` as a context manager:

```python
"""
Syntax sugar which helps in celery tasks, cron jobs, and other scripts

Usage:
    with Tenant.objects.get(schema_name='test') as tenant:
        # run some code in tenant test
        # run some code in previous tenant (public probably)
"""
```

...but for that to work, and for the `tenant` identifier in the `as` clause to be bound to the tenant, it needs to return a copy of `self` as well.

See Python [docs](https://docs.python.org/3.8/library/stdtypes.html#contextmanager.__enter__) for details.