### PR TITLE
fix(migrations): Fix migrate_schemas not working on Django 3.1

### DIFF
--- a/django_tenants/management/commands/migrate_schemas.py
+++ b/django_tenants/management/commands/migrate_schemas.py
@@ -35,6 +35,8 @@ class MigrateSchemasCommand(SyncCommon):
         )
         parser.add_argument('--run-syncdb', action='store_true', dest='run_syncdb',
                             help='Creates tables for apps without migrations.')
+        parser.add_argument('--check', action='store_true', dest='check_unapplied',
+                            help='Exits with a non-zero status if unapplied migrations exist.')
 
     def handle(self, *args, **options):
         super().handle(*args, **options)


### PR DESCRIPTION
Django 3.1 adds a new option for the `migrate` management command, and the Migration handler expects to have a key named `check_applied` in the options dict.
As of today, migrations crash with Django 3.1 and the master branch of django-tenants.
Adding this new option to the parser fixes the issue.