### PR TITLE
Add a signal that gets sent after migrations finish for a schema

### DIFF
--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -3,6 +3,8 @@ import sys
 from django.db import transaction
 
 from django.core.management.commands.migrate import Command as MigrateCommand
+
+from django_tenants.signals import schema_migrated
 from django_tenants.utils import get_public_schema_name, get_tenant_database_alias
 
 
@@ -47,6 +49,7 @@ def run_migrations(args, options, executor_codename, schema_name, allow_atomic=T
         pass
 
     connection.set_schema_to_public()
+    schema_migrated.send(run_migrations, schema_name=schema_name)
 
 
 class MigrationExecutor:

--- a/django_tenants/signals.py
+++ b/django_tenants/signals.py
@@ -12,6 +12,11 @@ schema_needs_to_be_sync.__doc__ = """
 Schema needs to be synced
 """
 
+schema_migrated = Signal(providing_args=['schema_name'])
+schema_migrated.__doc__ = """
+Sent after migration has finished on a schema
+"""
+
 
 @receiver(post_delete)
 def tenant_delete_callback(sender, instance, **kwargs):

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -111,11 +111,13 @@ Signals
 -------
 
 
-There are two signal one called ```post_schema_sync``` and the other called ```schema_needs_to_be_sync```
+There are three signal, ```post_schema_sync```, ```schema_needs_to_be_sync``` and ```schema_migrated```.
 
-```post_schema_sync``` will get called after the schema been migrated.
+```post_schema_sync``` will get called after a schema gets created from the save method on the tenant class.
 
 ```schema_needs_to_be_sync``` will get called if the schema needs to be migrated. ```auto_create_schema``` (on the tenant model) has to be set to False for this signal to get called. This signal is very useful when tenants are created via a background process such as celery.
+
+```schema_migrated``` will get called once migrations finish running for a schema.
 
 Example
 
@@ -134,6 +136,13 @@ Example
         client = kwargs['tenant']
 
         # send email to client to as tenant is ready to use
+
+    @receiver(schema_migrated, sender=run_migrations)
+    def handle_schema_migrated(sender, **kwargs):
+        schema_name = kwargs['schema_name']
+
+        # recreate materialized views in the schema
+
 
 Other settings
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Hi - I'll explain my motivation for this PR first and the details bellow.

In the project I'm working on we utilize materialized views to calculate statistics to prevent querying for them over and over. We're currently migrating to using django-tenants and that presented me with a problem implementing the materialized views.  In the package that I am using for the materialized views (django-pgviews), the views get synced after migrations finish. To continue having this behaviour (it's very useful, as e.g. you'd want to have the views sync after you create a tenant, no extra coding needed if runs after each migrate) I needed a way of knowing when migrations finish for each tenant, so I can recreate/refresh materialized views for the tenant, they often rely on the migrations. Turned out to be bit difficult out of the box. This is where this signal comes in.

There is current a signal called `post_schema_sync`, which however only gets called when a tenant is created (and only if it's created from calling `save()`). So to achieve the scenario I described above I had to:
  - override migrate_schemas to be able to
  - override the executor to be able to 
  - send a signal 
  - register a receiver for the signal which runs the code syncing materialized views (that bit is completely ok, just the schema needs to be active)

But with the introduction of the signal I implemented in this PR, the process would shrink down to just registering the receiver. I'm sure this is not a singular usecase, I think it could be useful for other stuff as well.

The signal gets called in the process where the migration is running, so that's why there's the conditions in the tests for executor, if the executor is multiprocessing then the signal gets sent in a different process (but it can still be caught there).

Btw, if this gets rejected - would you welcome a PR implementing customisable executors (so in my code I would be able to just override the executor which would send the signal)?