### PR TITLE
Simplify test client

### DIFF
--- a/django_tenants/test/client.py
+++ b/django_tenants/test/client.py
@@ -49,36 +49,11 @@ class TenantClient(Client):
         super().__init__(enforce_csrf_checks, **defaults)
         self.tenant = tenant
 
-    def get(self, path, data={}, **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
+    def generic(self, *args, **kwargs):
+        if "HTTP_HOST" not in kwargs:
+            kwargs["HTTP_HOST"] = self.tenant.get_primary_domain().domain
+        return super().generic(*args, **kwargs)
 
-        return super().get(path, data, **extra)
-
-    def post(self, path, data={}, **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().post(path, data, **extra)
-
-    def patch(self, path, data={}, **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().patch(path, data, **extra)
-
-    def put(self, path, data={}, **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().put(path, data, **extra)
-
-    def delete(self, path, data='', **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().delete(path, data, **extra)
-    
     def login(self, **credentials):
         # Create a dummy HttpRequest object and add HTTP_HOST
 

--- a/django_tenants/test/client.py
+++ b/django_tenants/test/client.py
@@ -11,49 +11,13 @@ class TenantRequestFactory(RequestFactory):
         super().__init__(**defaults)
         self.tenant = tenant
 
-    def get(self, path, data={}, **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().get(path, data, **extra)
-
-    def post(self, path, data={}, **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().post(path, data, **extra)
-
-    def patch(self, path, data={}, **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().patch(path, data, **extra)
-
-    def put(self, path, data={}, **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().put(path, data, **extra)
-
-    def delete(self, path, data='', **extra):
-        if 'HTTP_HOST' not in extra:
-            extra['HTTP_HOST'] = self.tenant.get_primary_domain().domain
-
-        return super().delete(path, data, **extra)
-
-
-class TenantClient(Client):
-    tm = TenantMainMiddleware()
-
-    def __init__(self, tenant, enforce_csrf_checks=False, **defaults):
-        super().__init__(enforce_csrf_checks, **defaults)
-        self.tenant = tenant
-
     def generic(self, *args, **kwargs):
         if "HTTP_HOST" not in kwargs:
             kwargs["HTTP_HOST"] = self.tenant.get_primary_domain().domain
         return super().generic(*args, **kwargs)
 
+
+class TenantClient(TenantRequestFactory, Client):
     def login(self, **credentials):
         # Create a dummy HttpRequest object and add HTTP_HOST
 


### PR DESCRIPTION
Hello all,

we started to use `django-tenants` and we are grateful to the authors for creating this package. Thanks!

Nevertheless, we use django-rest-framework and use the `APIClient` for testing. And, in order to make it compatible with `django-tenants`, we had to patch quite a lot of `TenantClient`methods:

```python
class APITenantClient(TenantClient, APIClient):
    def get(self, path, data=None, **extra):
        return super().get(path, data, **extra)

    def post(self, path, data=None, **extra):
        return super().post(path, data, **extra)

    def patch(self, path, data=None, **extra):
        return super().patch(path, data, **extra)

    def put(self, path, data=None, **extra):
        return super().put(path, data, **extra)

    def delete(self, path, data=None, **extra):
        return super().delete(path, data, **extra)

    def _generic(self, method, path, data, **kwargs):
        if method == "get":
            return self.get(path, None, **kwargs)
        elif method == "post":
            return self.post(path, data, **kwargs)
        elif method == "put":
            return self.put(path, data, **kwargs)
        elif method == "patch":
            return self.patch(path, data, **kwargs)
        elif method == "delete":
            return self.delete(path, data, **kwargs)
```

as 

1. the `data` defaults in  `TenantClient` break the usage of `APIClient`
2. the `generic` method does not work in the "tenant" environment (in fact, we have to use `client._generic` instead of `client.generic`)

The proposed change makes the `TenantClient` practically a drop-in replacement for the `django.test.Client` and it simplifies the creation of "APITenantClient" to just:
```python
class APITenantClient(TenantClient, APIClient):
    pass
```

Hope you will consider this an improvement for the `django-tenants` package. Actually, it may break a few thinks as it returns the control of defaults to the `django.test.Client`, so I'll be happy to turn this client to a new class instead of breaking the old one.
With regards
Krystof