### PR TITLE
Return the request from the main middleware

### DIFF
--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -38,13 +38,13 @@ class TenantMainMiddleware(MiddlewareMixin):
         try:
             tenant = self.get_tenant(domain_model, hostname)
         except domain_model.DoesNotExist:
-            self.no_tenant_found(request, hostname)
-            return
+            return self.no_tenant_found(request, hostname)
 
         tenant.domain_url = hostname
         request.tenant = tenant
         connection.set_tenant(request.tenant)
         self.setup_url_routing(request)
+        return request
 
     def no_tenant_found(self, request, hostname):
         """ What should happen if no tenant is found.


### PR DESCRIPTION
Actually return the request after meddling with it, since this is what django expects.
Also allow for more return values when tenant is not found.