### PR TITLE
Move the extra extensions validations in utils and clone the django connection  after the extra extension check.

### DIFF
--- a/django_tenants/utils.py
+++ b/django_tenants/utils.py
@@ -237,3 +237,32 @@ def parse_tenant_config_path(config_path):
     except (TypeError, ValueError):
         # No %s in string; append schema name at the end
         return os.path.join(config_path, connection.schema_name)
+
+
+def validate_extra_extensions():
+    extra_extensions = getattr(settings, 'PG_EXTRA_SEARCH_PATHS', [])
+
+    if get_public_schema_name() in extra_extensions:
+        raise ImproperlyConfigured(
+            "%s can not be included on PG_EXTRA_SEARCH_PATHS."
+            % get_public_schema_name())
+
+    # make sure no tenant schema is in settings.PG_EXTRA_SEARCH_PATHS
+
+    # first check that the model table is created
+    model = get_tenant_model()
+    with connection.cursor() as cursor:
+        cursor.execute(
+            'SELECT 1 FROM information_schema.tables WHERE table_name = %s;',
+            [model._meta.db_table]
+        )
+        if cursor.fetchone():
+            invalid_schemas = set(extra_extensions).intersection(
+                model.objects.all().values_list('schema_name', flat=True))
+            if invalid_schemas:
+                raise ImproperlyConfigured(
+                    "Do not include tenant schemas (%s) on PG_EXTRA_SEARCH_PATHS."
+                    % list(invalid_schemas))
+
+    # Make sure the connection used for the check is not reused and doesn't stay idle.
+    connection.close()


### PR DESCRIPTION
In the app.py there is a check that validates if the extra extensions are properly configured.

I have some concerns about this check:
- It prevents the use of a django command if the db is not yet created.
- It opens a connection that will not be reused and will remain inactive since the end of your connection time.

There are many solutions to solve the problem of idle connection problem:
- The first one is to close the connection after the execution of the queries to make sure that the connection will not remain idle.
- The second is to remove this check completely as it is not recommended to make a database query in the `apps.ready' file.
- Finally, we could do this check when a new connection is created using the signal created by the django database.

Let me know what you think is the best solution.

![image](https://user-images.githubusercontent.com/1457435/103926895-91e05e00-50e7-11eb-8849-bd8d5c94f60c.png)

Idle connections when you start a server before the fix:
![image](https://user-images.githubusercontent.com/1457435/103926761-5fcefc00-50e7-11eb-9aee-2e9bba7cc693.png)

Fixed version:
![image](https://user-images.githubusercontent.com/1457435/103927179-ee437d80-50e7-11eb-8af7-9bcc7c02831c.png)

