### PR TITLE
Update admin support to handle apps with a customized label

### DIFF
--- a/django_tenants/templatetags/tenant.py
+++ b/django_tenants/templatetags/tenant.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.conf import settings
 from django.template import Library
 from django.template.defaulttags import URLNode
@@ -35,7 +36,9 @@ def is_tenant_app(context, app):
             return True
     else:
         _apps = settings.TENANT_APPS
-    return app['app_label'] in [tenant_app.split('.')[-1] for tenant_app in _apps]
+
+    cfg = apps.get_app_config(app['app_label'])
+    return cfg.module.__name__ in _apps
 
 
 @register.simple_tag()
@@ -44,7 +47,9 @@ def is_shared_app(app):
         _apps = get_tenant_types()[get_public_schema_name()]['APPS']
     else:
         _apps = settings.SHARED_APPS
-    return app['app_label'] in [tenant_app.split('.')[-1] for tenant_app in _apps]
+
+    cfg = apps.get_app_config(app['app_label'])
+    return cfg.module.__name__ in _apps
 
 
 @register.simple_tag()


### PR DESCRIPTION
- This changes the templatetags for the admin template to correctly
identify apps in settings.SHARED_APPS if they have customized their
label and don't follow the default pattern.