### PR TITLE
Fix and simplify calculation of cache_key in cached template loader

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,8 +261,8 @@ env variable) or use `docker-compose`_ like this:
     # pip install docker-compose
 
     ## In main directory of this repo do:
-    docker-compose up postgres  # starts dockerized PostgreSQL service
-    docker-compose run django-tenants-test  # runs django-tenants tests
+    docker-compose run --rm django-tenants-test  # runs django-tenants tests.
+    # dockerized PostgreSQL service is started implicitly
 
 (note that upon first run the ``Dockerfile`` will be built).
 

--- a/django_tenants/tests/template/loaders/test_cached.py
+++ b/django_tenants/tests/template/loaders/test_cached.py
@@ -28,7 +28,7 @@ class TenantCachedLoaderTestCase(TenantTestCase):
     def test_cache_key(self):
         loader = self.engine.template_loaders[0]
         self.assertEqual(
-            loader.cache_key("index.html"), "index.html-{}".format(self.tenant.pk)
+            loader.cache_key("index.html"), "{}-index.html".format(self.tenant.schema_name)
         )
 
     def test_get_template(self):
@@ -42,7 +42,7 @@ class TenantCachedLoaderTestCase(TenantTestCase):
         )
 
         cache = self.engine.template_loaders[0].get_template_cache
-        self.assertEqual(cache["index.html-{}".format(self.tenant.pk)], template)
+        self.assertEqual(cache["{}-index.html".format(self.tenant.schema_name)], template)
 
         # Run a second time from cache
         template = self.engine.get_template("index.html")

--- a/django_tenants/tests/template/loaders/test_filesystem.py
+++ b/django_tenants/tests/template/loaders/test_filesystem.py
@@ -118,7 +118,7 @@ class TenantCachedLoaderTestCase(TenantTestCase):
     def test_cache_key(self):
         loader = self.engine.template_loaders[0]
         self.assertEqual(
-            loader.cache_key("index.html"), "index.html-{}".format(self.tenant.pk)
+            loader.cache_key("index.html"), "{}-index.html".format(self.tenant.schema_name)
         )
 
     def test_get_template(self):
@@ -132,7 +132,7 @@ class TenantCachedLoaderTestCase(TenantTestCase):
         )
 
         cache = self.engine.template_loaders[0].get_template_cache
-        self.assertEqual(cache["index.html-{}".format(self.tenant.pk)], template)
+        self.assertEqual(cache["{}-index.html".format(self.tenant.schema_name)], template)
 
         # Run a second time from cache
         template = self.engine.get_template("index.html")


### PR DESCRIPTION
- use calculations of parent class as base
- avoid throwing an exception if the tenant is a FakeTenant
- (brings this repo and django-tenant-schemas a bit closer together)

bonus:
- simplify instructions for testing on docker