### PR TITLE
Fix for Using collectstatic_schemas in django 3.1.x fails

### DIFF
--- a/django_tenants/management/commands/collectstatic_schemas.py
+++ b/django_tenants/management/commands/collectstatic_schemas.py
@@ -3,4 +3,5 @@ from django.contrib.staticfiles.management.commands import collectstatic
 
 
 class Command(TenantWrappedCommand):
+    requires_system_checks = []
     COMMAND = collectstatic.Command


### PR DESCRIPTION
This is a fix for the issue when using collectstatic_schemas in combination with django 3.1 or newer, that the command fails with: "argparse.ArgumentError: argument --skip-checks: conflicting option string: --skip-checks".

See issue: #580 

This patch is copied from: https://github.com/bernardopires/django-tenant-schemas/pull/650/commits
and especially: https://github.com/bernardopires/django-tenant-schemas/pull/650/commits/c25b27666afa9958399ba8d3b428024ae41b0c02#diff-f3d37263ffe8147dde1bee2da836b530bb3cac9ea6a4f4daa2f7ab7a506e2bfa