### PR TITLE
fix save to work for tenants with default value pk

### DIFF
--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -91,7 +91,7 @@ class TenantMixin(models.Model):
 
     def save(self, verbosity=1, *args, **kwargs):
         connection = connections[get_tenant_database_alias()]
-        is_new = self.pk is None
+        is_new = self._state.adding
         has_schema = hasattr(connection, 'schema_name')
         if has_schema and is_new and connection.schema_name != get_public_schema_name():
             raise Exception("Can't create tenant outside the public schema. "


### PR DESCRIPTION
Updates the `is_new` flag in the `TenantMixin` save method to use `self._state.adding` ([see docs here](https://docs.djangoproject.com/en/3.2/ref/models/instances/#state)) instead of `pk is None`.  When a model defines a primary key with a default value, pk will not be None even it it's not saved yet.  For example:
```python
class Client(TenantMixin):
    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
    # ... more fields
```
This tenant would set `self.pk` to `uuid.uuid4()`, which means the `self.pk is None` check would be `False` because `self.pk` is a UUID.