### PR TITLE
fix: WSGIRequest object has no attribute tenant

### DIFF
--- a/django_tenants/middleware/subfolder.py
+++ b/django_tenants/middleware/subfolder.py
@@ -52,7 +52,7 @@ class TenantSubfolderMiddleware(TenantMainMiddleware):
             except tenant_model.DoesNotExist:
                 raise self.TENANT_NOT_FOUND_EXCEPTION("Unable to find public tenant")
 
-            self.setup_url_routing(request)
+            self.setup_url_routing(request, force_public=True)
 
         # We are in a specific tenant
         else:


### PR DESCRIPTION
Fixes error while trying to access root folder (http://localhost/) using `TenantSubfolderMiddleware` class.

```text
Traceback (most recent call last):
  File "django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "django/utils/deprecation.py", line 116, in __call__
    response = self.process_request(request)
  File "/code/lomis/tenants/middleware.py", line 28, in process_request
    super().process_request(request)
  File "django_tenants/middleware/subfolder.py", line 55, in process_request
    self.setup_url_routing(request)
  File "django_tenants/middleware/main.py", line 79, in setup_url_routing
    (force_public or request.tenant.schema_name == get_public_schema_name())):

Exception Type: AttributeError at /
Exception Value: 'WSGIRequest' object has no attribute 'tenant'
```

| AttributeError at / | |
| --- | --- |
| Request Method: | GET |
| Request URL: | http://localhost/ |
| Django Version: | 3.2.6 |
| Exception Type: | AttributeError |
| Exception Value: | 'WSGIRequest' object has no attribute 'tenant' |
| Exception Location: | django_tenants/middleware/main.py, line 79, in setup_url_routing |
| Python Version: | 3.8.11 |
