### PR TITLE
fix: add newline to codeblock

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -560,6 +560,7 @@ Useful information
 If you want to run some code on every tenant you can do the following
 
 .. code-block:: python
+
     #import tenant model
     from django_tenants.utils import tenant_context
 


### PR DESCRIPTION
Not sure if this fixes the problem - but the last code block in the docs does not render at all:
https://django-tenants.readthedocs.io/en/latest/use.html#useful-information
I'm hopeful the newline makes the difference, based on every other block in this file having one.