### PR TITLE
Docs: Remove django.contrib.contenttypes from TENANT_APPS. Closes #273

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -118,9 +118,6 @@ To make use of shared and tenant-specific applications, there are two settings c
     )
 
     TENANT_APPS = (
-        # The following Django contrib apps must be in TENANT_APPS
-        'django.contrib.contenttypes',
-
         # your tenant-specific apps
         'myapp.hotels',
         'myapp.houses',


### PR DESCRIPTION
I've been running without this setting in TENANT_APPS for 2.5 years now and haven't seen any issues so I propose removing it. 

Maybe it is only necessary if you have other TENANT_APPS which require it, IDK. Although in https://github.com/django-tenants/django-tenants/issues/273#issuecomment-489220660 I also point out that django_comments worked as expected so not sure. 

Proposing doc update b/c other comments on 273 seem to agree that we don't need contenttypes in TENANT_APPS. 

