### PR TITLE
Enable to order tenants when migrating schemas

### DIFF
--- a/django_tenants/management/commands/migrate_schemas.py
+++ b/django_tenants/management/commands/migrate_schemas.py
@@ -1,6 +1,6 @@
 from django_tenants.migration_executors import get_executor
 from django_tenants.utils import get_tenant_model, get_public_schema_name, schema_exists, get_tenant_database_alias, \
-    has_multi_type_tenants, get_multi_type_database_field_name
+    has_multi_type_tenants, get_multi_type_database_field_name, get_tenant_migration_order
 from django_tenants.management.commands import SyncCommon
 
 
@@ -65,17 +65,27 @@ class MigrateSchemasCommand(SyncCommon):
                     tenants = [self.schema_name]
                     executor.run_migrations(tenants=tenants)
             else:
+                migration_order = get_tenant_migration_order()
+
                 if has_multi_type_tenants():
                     type_field_name = get_multi_type_database_field_name()
                     tenants = get_tenant_model().objects.only('schema_name', type_field_name)\
                         .exclude(schema_name=self.PUBLIC_SCHEMA_NAME)\
                         .values_list('schema_name', type_field_name)
+
+                    if migration_order is not None:
+                        tenants = tenants.order_by(*migration_order)
+
                     executor.run_multi_type_migrations(tenants=tenants)
                 else:
                     tenants = get_tenant_model().objects.only(
                         'schema_name').exclude(
                         schema_name=self.PUBLIC_SCHEMA_NAME).values_list(
                         'schema_name', flat=True)
+
+                    if migration_order is not None:
+                        tenants = tenants.order_by(*migration_order)
+
                     executor.run_migrations(tenants=tenants)
 
 

--- a/django_tenants/utils.py
+++ b/django_tenants/utils.py
@@ -99,6 +99,10 @@ def get_tenant_base_schema():
     return schema
 
 
+def get_tenant_migration_order():
+    return getattr(settings, 'TENANT_MIGRATION_ORDER', None)
+
+
 class schema_context(ContextDecorator):
     # Please do not try and merge this with tenant_context as they are not the same. As pointed out in #501
     def __init__(self, *args, **kwargs):

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -247,6 +247,12 @@ Optional Settings
         # ..
     ]
 
+.. attribute:: TENANT_MIGRATION_ORDER
+
+    :Default: ``None``
+
+    A list of fields to order the tenant queryset by when migrating schemas.
+
 
 Tenant View-Routing
 -------------------


### PR DESCRIPTION
In our usage of this package at my company we have "active" and "deactivated" tenants and when migrating we'd like to migrate active tenants first - without overriding the entire command it's not currently possible, so adding a way to do that.