### PR TITLE
Custom Tenant Apps Feature

### DIFF
--- a/django_tenants/apps.py
+++ b/django_tenants/apps.py
@@ -3,7 +3,6 @@ from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
 from django_tenants.utils import get_public_schema_name, validate_extra_extensions
 
-
 recommended_config = """
 Warning: The recommend way of setting django tenants up is shown in the documentation.
 Please see https://django-tenants.readthedocs.io/en/latest/install.html?highlight=#configure-tenant-and-shared-applications
@@ -27,6 +26,19 @@ class DjangoTenantsConfig(AppConfig):
                 raise ImproperlyConfigured('get_public_schema_name() value not found as a key in TENANTS')
             if not hasattr(settings, 'MULTI_TYPE_DATABASE_FIELD'):
                 raise ImproperlyConfigured('Using multi type you must setup MULTI_TYPE_DATABASE_FIELD setting')
+        elif hasattr(settings, 'HAS_CUSTOM_TENANT_APPS') and settings.HAS_CUSTOM_TENANT_APPS:
+            if not hasattr(settings, 'MANDATORY_TENANT_APPS'):
+                raise ImproperlyConfigured('Using custom tenant apps you must set up MANDATORY_TENANT_APPS')
+            if not hasattr(settings, 'OPTIONAL_TENANT_APPS'):
+                raise ImproperlyConfigured('Using custom tenant apps you must set up OPTIONAL_TENANT_APPS')
+            if not hasattr(settings, 'TENANT_APPS'):
+                raise ImproperlyConfigured('TENANT_APPS setting not set')
+
+            from .utils import get_tenant_model
+            from .models import TenantWithCustomAppsMixin
+            if not issubclass(get_tenant_model(), TenantWithCustomAppsMixin):
+                raise ImproperlyConfigured('The tenant model must inherit TenantWithCustomAppsMixin when '
+                                           'HAS_CUSTOM_TENANT_APPS is True')
         else:
             if not hasattr(settings, 'TENANT_APPS'):
                 raise ImproperlyConfigured('TENANT_APPS setting not set')

--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -9,7 +9,7 @@ from django_tenants.utils import get_public_schema_name, get_tenant_database_ali
 
 
 def run_migrations(args, options, executor_codename, schema_name, tenant_type='',
-                   allow_atomic=True, idx=None, count=None):
+                   allow_atomic=True, idx=None, count=None, custom_tenant_apps=[]):
     from django.core.management import color
     from django.core.management.base import OutputWrapper
     from django.db import connections
@@ -36,7 +36,7 @@ def run_migrations(args, options, executor_codename, schema_name, tenant_type=''
         return message
 
     connection = connections[options.get('database', get_tenant_database_alias())]
-    connection.set_schema(schema_name, tenant_type=tenant_type)
+    connection.set_schema(schema_name, tenant_type=tenant_type, custom_tenant_apps=custom_tenant_apps)
 
     stdout = OutputWrapper(sys.stdout)
     stdout.style_func = style_func
@@ -75,4 +75,7 @@ class MigrationExecutor:
         raise NotImplementedError
 
     def run_multi_type_migrations(self, tenants):
+        raise NotImplementedError
+
+    def run_custom_apps_migrations(self, tenants):
         raise NotImplementedError

--- a/django_tenants/migration_executors/standard.py
+++ b/django_tenants/migration_executors/standard.py
@@ -24,3 +24,15 @@ class StandardExecutor(MigrationExecutor):
                            tenant_type=tenant[1],
                            idx=idx,
                            count=len(tenants))
+
+    def run_custom_apps_migrations(self, tenants):
+        tenants = tenants or []
+
+        for idx, tenant in enumerate(tenants):
+            run_migrations(self.args,
+                           self.options,
+                           self.codename,
+                           schema_name=tenant[0],
+                           custom_tenant_apps=tenant[1],
+                           idx=idx,
+                           count=len(tenants))

--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -73,13 +73,14 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         # wrong model will be fetched.
         ContentType.objects.clear_cache()
 
-    def set_schema(self, schema_name, include_public=True, tenant_type=None):
+    def set_schema(self, schema_name, include_public=True, tenant_type=None, custom_tenant_apps=None):
         """
         Main API method to current database schema,
         but it does not actually modify the db connection.
         """
         self.set_tenant(FakeTenant(schema_name=schema_name,
-                                   tenant_type=tenant_type), include_public)
+                                   tenant_type=tenant_type,
+                                   tenant_apps=custom_tenant_apps), include_public)
 
     def set_schema_to_public(self):
         """
@@ -166,9 +167,13 @@ class FakeTenant:
     We can't import any db model in a backend (apparently?), so this class is used
     for wrapping schema names in a tenant-like structure.
     """
-    def __init__(self, schema_name, tenant_type=None):
+    def __init__(self, schema_name, tenant_type=None, tenant_apps=None):
         self.schema_name = schema_name
         self.tenant_type = tenant_type
+        self.tenant_apps = tenant_apps
 
     def get_tenant_type(self):
         return self.tenant_type
+
+    def get_tenant_custom_apps(self):
+        return self.tenant_apps

--- a/django_tenants/routers.py
+++ b/django_tenants/routers.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.apps import apps as django_apps
 
-from django_tenants.utils import has_multi_type_tenants, get_tenant_types
+from django_tenants.utils import has_multi_type_tenants, get_tenant_types, has_custom_tenant_apps
 
 
 class TenantSyncRouter(object):
@@ -44,6 +44,11 @@ class TenantSyncRouter(object):
             else:
                 tenant_type = connection.tenant.get_tenant_type()
                 installed_apps = tenant_types[tenant_type]['APPS']
+        elif has_custom_tenant_apps():
+            if connection.schema_name == public_schema_name:
+                installed_apps = settings.SHARED_APPS
+            else:
+                installed_apps = settings.MANDATORY_TENANT_APPS + connection.tenant.get_tenant_custom_apps()
         else:
             if connection.schema_name == public_schema_name:
                 installed_apps = settings.SHARED_APPS

--- a/django_tenants/templatetags/tenant.py
+++ b/django_tenants/templatetags/tenant.py
@@ -3,7 +3,8 @@ from django.conf import settings
 from django.template import Library
 from django.template.defaulttags import URLNode
 from django.template.defaulttags import url as default_url
-from django_tenants.utils import clean_tenant_url, get_public_schema_name, has_multi_type_tenants, get_tenant_types
+from django_tenants.utils import clean_tenant_url, get_public_schema_name, has_multi_type_tenants, get_tenant_types, \
+    has_custom_tenant_apps
 
 register = Library()
 
@@ -32,6 +33,11 @@ def is_tenant_app(context, app):
     if has_multi_type_tenants():
         if hasattr(context.request, 'tenant') and context.request.tenant is not None:
             _apps = get_tenant_types()[context.request.tenant.get_tenant_type()]['APPS']
+        else:
+            return True
+    elif has_custom_tenant_apps():
+        if hasattr(context.request, 'tenant') and context.request.tenant is not None:
+            _apps = settings.MANDATORY_TENANT_APPS + context.request.tenant.get_tenant_custom_apps()
         else:
             return True
     else:

--- a/django_tenants/utils.py
+++ b/django_tenants/utils.py
@@ -35,8 +35,24 @@ def get_tenant_types():
     return getattr(settings, 'TENANT_TYPES', {})
 
 
+def get_optional_tenant_apps():
+    return getattr(settings, 'OPTIONAL_TENANT_APPS', {})
+
+
+def get_optional_tenant_apps_list():
+    return [app['app'] for app in get_optional_tenant_apps()]
+
+
+def get_optional_tenant_apps_choices():
+    return [(app, app) for app in get_optional_tenant_apps_list()]
+
+
 def has_multi_type_tenants():
     return getattr(settings, 'HAS_MULTI_TYPE_TENANTS', False)
+
+
+def has_custom_tenant_apps():
+    return getattr(settings, 'HAS_CUSTOM_TENANT_APPS', False)
 
 
 def get_multi_type_database_field_name():


### PR DESCRIPTION
A feature to allow dynamically setting apps applicable for each tenant, an extension of Multi-type tenants. Set up the following in `settings.py`:
1. Set `HAS_CUSTOM_TENANT_APPS` to `True`.
2. Create a list `SHARED_APPS` as usual.
3. Instead of `TENANT_APPS` make two lists `MANDATORY_TENANT_APPS` and `OPTIONAL_TENANT APPS`. 
4. `MANDATORY_TENANT_APPS` consists of all apps required for all tenants such as `django.contrib.admin`.
5. `OPTIONAL_TENANT_APPS` should be a list of dictionaries consisting of two properties: `app` - the app name, and `dependencies` - a list of apps that this app depends on. (Then the admin user won't be able to add this app to a tenant without including its dependencies) For example,
`OPTIONAL_TENANT_APPS = [  
    {'app': 'authors', },
    {'app': 'books', 'dependencies': ['authors'], }
]`
6. Add the following code:
`TENANT_APPS = MANDATORY_TENANT_APPS + [app['app'] for app in OPTIONAL_TENANT_APPS]`
`INSTALLED_APPS = list(SHARED_APPS) + [app for app in TENANT_APPS if app not in SHARED_APPS]`

A new Tenant Mixin `TenantWithCustomAppsMixin` manages migrations when (such as remove migrations and tables when an app is removed from apps of the tenant, and migrate tables when a new app is added) `auto_migrations_on_apps_change` property is set to true.

One possible improvement — the URLs can be made resolved on a tenant-specific basis. One way is perhaps to include a URLs property on `OPTIONAL_TENANT_APPS ` which can be used by a middleware to only allow relevant URLs for the tenant.

A sample application is [here](https://github.com/django-tenants/django-tenants/files/7527483/Python.zip).
