### PR TITLE
skipping checks in collect_static (required for django 3.2)

### DIFF
--- a/django_tenants/management/commands/collectstatic_schemas.py
+++ b/django_tenants/management/commands/collectstatic_schemas.py
@@ -5,3 +5,13 @@ from django.contrib.staticfiles.management.commands import collectstatic
 class Command(TenantWrappedCommand):
     requires_system_checks = []
     COMMAND = collectstatic.Command
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--skip-checks",
+            action="store_true",
+            dest="skip_checks",
+            default=False,
+            help="Skip the checks.",
+        )


### PR DESCRIPTION
This is a fix for the collect_static issue when using django 3.2.

It is using the code from here: https://github.com/django-tenants/django-tenants/issues/580#issuecomment-935974452

I have tried to run the tests, but the description for how to run them (using docker) where not complete or working. So I am not sure if all tests pass. However, I have tested it empirically and the fix works.