### PR TITLE
Ensure django_migrations table is created in a schema before migrations begin

### DIFF
--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -3,6 +3,7 @@ import sys
 from django.db import transaction
 
 from django.core.management.commands.migrate import Command as MigrateCommand
+from django.db.migrations.recorder import MigrationRecorder
 
 from django_tenants.signals import schema_migrated, schema_migrate_message
 from django_tenants.utils import get_public_schema_name, get_tenant_database_alias
@@ -37,6 +38,11 @@ def run_migrations(args, options, executor_codename, schema_name, tenant_type=''
 
     connection = connections[options.get('database', get_tenant_database_alias())]
     connection.set_schema(schema_name, tenant_type=tenant_type)
+
+    # ensure that django_migrations table is created in the schema before migrations run, otherwise the migration
+    # table in the public schema gets picked and no migrations are applied
+    migration_recorder = MigrationRecorder(connection)
+    migration_recorder.ensure_schema()
 
     stdout = OutputWrapper(sys.stdout)
     stdout.style_func = style_func


### PR DESCRIPTION
This should fix https://github.com/django-tenants/django-tenants/issues/702

I've done some digging and I think the cause of the bug in #702 is that when the migrations run for the first time, the search path is set to the new schema and public but there is no `django_tenants` . So when the migrations run, there's a query to see which migrations haven't been applied, since there is no `django_tenants` table in the new schema, it looks at the table in the public schema where all migrations have been applied, so no migrations are run. Then the `django_tenants` table is somehow actually created in the new schema. This means that next time the migrations run, it correctly picks up the empty table and runs all migrations.

This PR makes sure that the `django_tenants` exists before running any migrations, fixing the issue.