### PR TITLE
less field pull from db for middleware

### DIFF
--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -24,7 +24,9 @@ class TenantMainMiddleware(MiddlewareMixin):
         return remove_www(request.get_host().split(':')[0])
 
     def get_tenant(self, domain_model, hostname):
-        domain = domain_model.objects.select_related('tenant').get(domain=hostname)
+        domain = domain_model.objects.select_related('tenant').only(
+            'tenant__id', 'tenant__schema_name'
+        ).get(domain=hostname)
         return domain.tenant
 
     def process_request(self, request):


### PR DESCRIPTION
While testing the performance of my application, I noticed a place for improvement. Since I added my own fields to the client model, the middleware was pulling all the fields each time.
#### Before
```bash
   SET search_path = 'public'
Execution time: 0.001069s [Database: default]
SELECT "customers_domain"."id",
       "customers_domain"."domain",
       "customers_domain"."tenant_id",
       "customers_domain"."is_primary",
       "customers_client"."id",
       "customers_client"."schema_name",
       "customers_client"."name",
       "customers_client"."subscription_type",
       "customers_client"."subscription_plan",
       "customers_client"."configuration",
       "customers_client"."created_on"
  FROM "customers_domain"
 INNER JOIN "customers_client"
    ON ("customers_domain"."tenant_id" = "customers_client"."id")
 WHERE "customers_domain"."domain" = 'test.localhost'
 LIMIT 21
Execution time: 0.001684s [Database: default]
```

#### After
```bash
   SET search_path = 'public'
Execution time: 0.001048s [Database: default]
SELECT "customers_domain"."id",
       "customers_domain"."tenant_id",
       "customers_client"."id",
       "customers_client"."schema_name"
  FROM "customers_domain"
 INNER JOIN "customers_client"
    ON ("customers_domain"."tenant_id" = "customers_client"."id")
 WHERE "customers_domain"."domain" = 'test.localhost'
 LIMIT 21
Execution time: 0.001059s [Database: default]
```