### PR TITLE
[RFC] Add TenantDirectFolderMiddleware

### DIFF
--- a/django_tenants/middleware/__init__.py
+++ b/django_tenants/middleware/__init__.py
@@ -2,6 +2,7 @@ import warnings
 
 from django_tenants.middleware.main import TenantMainMiddleware
 from django_tenants.middleware.subfolder import TenantSubfolderMiddleware
+from django_tenants.middleware.directfolder import TenantDirectFolderMiddleware
 
 
 class TenantMiddleware(TenantMainMiddleware):

--- a/django_tenants/middleware/directfolder.py
+++ b/django_tenants/middleware/directfolder.py
@@ -1,0 +1,67 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import connection
+from django.http import Http404
+from django.urls import set_urlconf, clear_url_caches
+from django_tenants.middleware import TenantMainMiddleware
+from django_tenants.urlresolvers import get_subfolder_urlconf
+from django_tenants.utils import (
+    get_public_schema_name,
+    get_tenant_model,
+    get_tenant_domain_model,
+)
+
+class TenantDirectFolderMiddleware(TenantMainMiddleware):
+    """
+    This middleware should be placed at the very top of the middleware stack.
+    Selects the proper tenant using the path direct folder. Can fail in
+    various ways which is better than corrupting or revealing data.
+    """
+
+    TENANT_NOT_FOUND_EXCEPTION = Http404
+
+    def __init__(self, get_response=None):
+        super().__init__(get_response)
+        self.get_response = get_response
+
+    def process_request(self, request):
+        # Short circuit if tenant is already set by another middleware.
+        # This allows for multiple tenant-resolving middleware chained together.
+        if hasattr(request, "tenant"):
+            return
+
+        connection.set_schema_to_public()
+
+        urlconf = None
+
+        tenant_model = get_tenant_model()
+        domain_model = get_tenant_domain_model()
+        hostname = self.hostname_from_request(request)
+        path_chunks = request.path.split("/")
+        tenant_subfolder = path_chunks[1]
+
+        try:
+            tenant = self.get_tenant(domain_model=domain_model, hostname=tenant_subfolder)
+
+            tenant.domain_url = hostname
+            tenant.domain_subfolder = tenant_subfolder
+            urlconf = get_subfolder_urlconf(tenant)
+        except ObjectDoesNotExist:
+            try:
+                tenant = tenant_model.objects.get(schema_name=get_public_schema_name())
+            except ObjectDoesNotExist:
+                return self.no_tenant_found(request, hostname=tenant_subfolder)
+
+        request.tenant = tenant
+        self.setup_url_routing(request)
+
+        connection.set_tenant(request.tenant)
+        clear_url_caches()  # Required to remove previous tenant prefix from cache, if present
+
+        if urlconf:
+            request.urlconf = urlconf
+            set_urlconf(urlconf)
+
+    def no_tenant_found(self, request, hostname):
+        """ What should happen if no tenant is found.
+        This makes it easier if you want to override the default behavior """
+        raise self.TENANT_NOT_FOUND_EXCEPTION('No tenant for subfolder "%s"' % hostname)

--- a/django_tenants/tests/test_routes.py
+++ b/django_tenants/tests/test_routes.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test.client import RequestFactory
 
-from django_tenants.middleware import TenantMainMiddleware, TenantSubfolderMiddleware
+from django_tenants.middleware import TenantMainMiddleware, TenantSubfolderMiddleware, TenantDirectFolderMiddleware
 from django_tenants.tests.testcases import BaseTestCase
 from django_tenants.utils import get_tenant_model, get_tenant_domain_model, get_public_schema_name
 
@@ -179,3 +179,108 @@ class SubfolderRoutesWithoutPrefixTestCase(BaseTestCase):
         settings.TENANT_SUBFOLDER_PREFIX = '  '
         with self.assertRaises(ImproperlyConfigured):
             TenantSubfolderMiddleware(lambda r: r)
+
+class DirectFolderRoutesTestCase(BaseTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        settings.SHARED_APPS = ('django_tenants',
+                                'customers')
+        settings.TENANT_APPS = ('dts_test_app',
+                                'django.contrib.contenttypes',
+                                'django.contrib.auth', )
+        settings.INSTALLED_APPS = settings.SHARED_APPS + settings.TENANT_APPS
+        cls.available_apps = settings.INSTALLED_APPS
+
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.td = TenantDirectFolderMiddleware(lambda r: r)
+
+        self.sync_shared()
+        self.public_tenant = get_tenant_model()(schema_name=get_public_schema_name())
+        self.public_tenant.save()
+        self.public_domain = get_tenant_domain_model()(domain='test.com', tenant=self.public_tenant)
+        self.public_domain.save()
+
+        self.tenant_domain = 'tenant.test.com'
+        self.tenant = get_tenant_model()(schema_name='test')
+        self.tenant.save()
+        self.domain = get_tenant_domain_model()(tenant=self.tenant, domain=self.tenant_domain)
+        self.domain.save()
+
+    def tearDown(self):
+        from django.db import connection
+
+        connection.set_schema_to_public()
+
+        self.domain.delete()
+        self.tenant.delete(force_drop=True)
+
+        self.public_domain.delete()
+        self.public_tenant.delete()
+
+        super().tearDown()
+
+    def test_already_fulfilled_tenant(self):
+        """
+        Request path should not be altered. Tenant should be already set.
+        """
+        request_url = '/test/any/request/'
+        request = self.factory.get(request_url,
+                                      HTTP_HOST=self.public_domain.domain)
+        request.tenant = self.tenant
+
+        self.td.process_request(request)
+
+        self.assertEqual(request.path_info, request_url)
+        self.assertEqual(request.tenant, self.tenant)
+        
+    def test_public_schema_routing(self):
+        """
+        Request path should not be altered. Tenant should be public schema.
+        """
+        request_url = '/any/request/'
+        request = self.factory.get(request_url,
+                                   HTTP_HOST=self.public_domain.domain)
+        self.td.process_request(request)
+
+        self.assertEqual(request.path_info, request_url)
+        self.assertEqual(request.tenant, self.public_tenant)
+
+    def test_tenant_routing(self):
+        """
+        Request path should not be altered. Tenant should have only name at domain.
+        """
+        tenant_domain = 'test1'
+        tenant = get_tenant_model()(schema_name='test1')
+        tenant.save()
+        domain = get_tenant_domain_model()(tenant=tenant, domain=tenant_domain)
+        domain.save()
+
+        request_url = '/test1/any/request/'
+        request = self.factory.get(request_url,
+                                   HTTP_HOST=self.public_domain.domain)
+        self.td.process_request(request)
+
+        self.assertEqual(request.path_info, request_url)
+
+        # request.tenant should also have been set
+        self.assertEqual(request.tenant, tenant)
+
+    # Needs mocking to test when public is not in the database, cannot run test because it's already set in setUp
+    # Will only fail when public tenant is not in the database
+    # def test_missing_tenant(self):
+    #     """
+    #     Request path should not be altered.
+    #     """
+
+    #     request = self.factory.get('/not-a-test/any/request/')
+
+    #     with self.assertRaises(self.td.TENANT_NOT_FOUND_EXCEPTION):
+    #         self.td.process_request(request)
+
+    #     self.public_tenant = get_tenant_model()(schema_name=get_public_schema_name())
+    #     self.public_tenant.save()
+    #     self.public_domain = get_tenant_domain_model()(domain='test.com', tenant=self.public_tenant)
+    #     self.public_domain.save()

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -225,8 +225,20 @@ The middleware is different to the standard middleware. The middleware required 
     )
 
 You shouldn't have any URL path at ``PUBLIC_SCHEMA_URLCONF`` URL's that may enter in conflit with any schemaname (if you are using it).
+It's recommended to split your URL's between ``ROOT_URLCONF`` for tenants and ``PUBLIC_SCHEMA_URLCONF`` for *public*.
 
-If the *schemaname* was not found, it will fallback to *public* as default, assuming *public* exists, otherwise it will throw an exception.
+.. code-block:: python
+
+    ROOT_URLCONF = "app.urls"
+    PUBLIC_SCHEMA_URLCONF = "app.urls_public"
+
+If you're using another middleware and want to change to ``TenantDirectFolderMiddleware``, you should probably create another entry at the **Domain** model table.
+Use the same name as the *schema_name* which the *schema* was created to match the path for the new middleware.
+When creating a tenant, use the *schema_name* as the *domain*.
+
+.. note::
+    
+    If the *schemaname* was not found, it will fallback to *public* as default, assuming *public* exists, otherwise it will throw an exception.
 
 Optional Settings
 =================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -203,6 +203,31 @@ The middleware is different to the standard middleware. The middleware required 
 
     There is an example project for this in the examples folder
 
+Direct-folder Support
+=====================
+
+Currently in beta.
+
+There is a option that allows you to run Django-Tenants with direct-folder instead of sub-domains.
+
+.. note::
+
+    ie http://www.mydomain.local/schemaname/ instead of http://schemaname.mydomain.local/
+
+
+The middleware is different to the standard middleware. The middleware required is
+
+.. code-block:: python
+
+    MIDDLEWARE = (
+        'django_tenants.middleware.TenantDirectFolderMiddleware',
+        #...
+    )
+
+You shouldn't have any URL path at ``PUBLIC_SCHEMA_URLCONF`` URL's that may enter in conflit with any schemaname (if you are using it).
+
+If the *schemaname* was not found, it will fallback to *public* as default, assuming *public* exists, otherwise it will throw an exception.
+
 Optional Settings
 =================
 


### PR DESCRIPTION
## Problem
We have just started a new project at the company that I work for, they've being using `django-tenants` for a while now, but they had some trouble dealing with tenant routing due to the fact [TenantSubfolderMiddleware](https://github.com/django-tenants/django-tenants/blob/688a7d2a001b8f8501dfdb59e1fc9ddc9f53818c/django_tenants/middleware/subfolder.py#L15) expects a prefix at the path string, so workarounds had to be done in order to get direct tenant paths.

In order to remove this complexity to get direct tenants at the path string (e.g. `https://example.com/tenant/some/route/for/it`), we started looking at the source code of this middleware to understand it and develop a new solution based on it.

## Solution
We've developed a simpler version of [TenantSubfolderMiddleware](https://github.com/django-tenants/django-tenants/blob/688a7d2a001b8f8501dfdb59e1fc9ddc9f53818c/django_tenants/middleware/subfolder.py#L15) called `TenantDirectFolderMiddleware`.

### How does it works?

1. It checks whether in the path string the first part is a tenant, we use the domain structure in a different way it was supposed to. Instead of using `tenant.example.com`, we simply use the name we're going to search for in the URL, like `tenant`. This should be taken in account at tenant creation.
2. If the tenant searched was not found, it will fallback to `public`.
3. If neither the tenant searched nor `public` is found, it will throw `TENANT_NOT_FOUND_EXCEPTION`. (If the public tenant wasn't found there is a big issue of configuration there...)
4. As the URLs are created dynamically, we need a way to tell the middleware which one he should pick, so you should define specific URLs to either public and tenant routes. After that you've to define them at `settings.py` like this:
```python
ROOT_URLCONF = "app.urls"
PUBLIC_SCHEMA_URLCONF = "app.urls_public"
```

## Known Limitations

1. You should be aware of the tenants domain names that are created, to avoid them colliding with public URLs (tenant domain has an equivalent route in `public`). This isn't done automatically.
2. This isn't tested against Multi-type tenants (we didn't have used this kind).

**We would like to know the contributors opinion about this PR.** 