### PR TITLE
Urlresolver optimization when using sub-folders

### DIFF
--- a/django_tenants/urlresolvers.py
+++ b/django_tenants/urlresolvers.py
@@ -30,10 +30,10 @@ class TenantPrefixPattern:
         subfolder_prefix = get_subfolder_prefix()
         try:
             # Store the domain to avoid multiple DB hits for the same domain in the same request
-            if self.cached_domain is not None \
-                    and self.cached_domain.domain == connection.tenant.domain_subfolder  \
-                    and self.cached_domain.tenant.schema_name == connection.schema_name:
-                        domain = self.cached_domain
+            if (self.cached_domain is not None and 
+                    self.cached_domain.domain == connection.tenant.domain_subfolder and 
+                    self.cached_domain.tenant.schema_name == connection.schema_name):
+                domain = self.cached_domain
 
             else:
                 domain = _DomainModel.objects.get(
@@ -41,6 +41,7 @@ class TenantPrefixPattern:
                     domain=connection.tenant.domain_subfolder,
                 )
                 self.cached_domain = domain
+                
             return (
                 "{}/{}/".format(subfolder_prefix, domain.domain)
                 if subfolder_prefix

--- a/django_tenants/urlresolvers.py
+++ b/django_tenants/urlresolvers.py
@@ -22,16 +22,25 @@ reverse_lazy = lazy(reverse, str)
 
 class TenantPrefixPattern:
     converters = {}
+    cached_domain = None
 
     @property
     def tenant_prefix(self):
         _DomainModel = get_tenant_domain_model()
         subfolder_prefix = get_subfolder_prefix()
         try:
-            domain = _DomainModel.objects.get(
-                tenant__schema_name=connection.schema_name,
-                domain=connection.tenant.domain_subfolder,
-            )
+            # Store the domain to avoid multiple DB hits for the same domain in the same request
+            if self.cached_domain is not None \
+                    and self.cached_domain.domain == connection.tenant.domain_subfolder  \
+                    and self.cached_domain.tenant.schema_name == connection.schema_name:
+                        domain = self.cached_domain
+
+            else:
+                domain = _DomainModel.objects.get(
+                    tenant__schema_name=connection.schema_name,
+                    domain=connection.tenant.domain_subfolder,
+                )
+                self.cached_domain = domain
             return (
                 "{}/{}/".format(subfolder_prefix, domain.domain)
                 if subfolder_prefix


### PR DESCRIPTION
Just a minor optimization to reduce the number of duplicate queries when using Django Tenants with sub-folders

I was using Django Toolbar to look through the views in my DRF project. When taking a closer look at my queries I saw that something in middleware was querying the same domain multiple times per request (13-20 times on average, when just navigating simple views and serializers)  

The tenant_prefix method in urlresolvers was being called multiple times and each time it ran the objects .get() method.

This behaviour only occurs when using sub-folders. There were no dubplicate queries when using the sub-domain approach.