### PR TITLE
Allow all_tenants_command to run excluding public schema

### DIFF
--- a/django_tenants/management/commands/all_tenants_command.py
+++ b/django_tenants/management/commands/all_tenants_command.py
@@ -21,7 +21,6 @@ class Command(BaseCommand):
         Changes the option_list to use the options from the wrapped command.
         """
         # load the command object.
-        print(argv)
         if len(argv) <= 3:
             return
         

--- a/django_tenants/management/commands/all_tenants_command.py
+++ b/django_tenants/management/commands/all_tenants_command.py
@@ -3,7 +3,7 @@ import argparse
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management import get_commands, load_command_class
 from django.db import connection
-from django_tenants.utils import get_tenant_model
+from django_tenants.utils import get_tenant_model, get_public_schema_name
 
 
 class Command(BaseCommand):
@@ -12,7 +12,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         super().add_arguments(parser)
-
+           
+        parser.add_argument('--no-public', nargs='?', const=True, default=False, help='Exclude the public schema')
         parser.add_argument('command_name', nargs='+', help='The command name you want to run')
 
     def run_from_argv(self, argv):
@@ -20,28 +21,31 @@ class Command(BaseCommand):
         Changes the option_list to use the options from the wrapped command.
         """
         # load the command object.
-        if len(argv) <= 2:
+        if len(argv) <= 3:
             return
         try:
-            app_name = get_commands()[argv[2]]
+            app_name = get_commands()[argv[3]]
         except KeyError:
-            raise CommandError("Unknown command: %r" % argv[2])
+            raise CommandError("Unknown command: %r" % argv[3])
 
         if isinstance(app_name, BaseCommand):
             # if the command is already loaded, use it directly.
             klass = app_name
         else:
-            klass = load_command_class(app_name, argv[2])
+            klass = load_command_class(app_name, argv[3])
 
         # Ugly, but works. Delete tenant_command from the argv, parse the schema manually
         # and forward the rest of the arguments to the actual command being wrapped.
         del argv[1]
+        del argv[2]
         schema_parser = argparse.ArgumentParser()
         schema_namespace, args = schema_parser.parse_known_args(argv)
         print(args)
 
         tenant_model = get_tenant_model()
         tenants = tenant_model.objects.all()
+        if argv[2]:
+            tenants = tenants.exclude(schema_name=get_public_schema_name())
         for tenant in tenants:
             self.stdout.write("Applying command to: %s" % tenant.schema_name)
             connection.set_tenant(tenant)

--- a/django_tenants/management/commands/all_tenants_command.py
+++ b/django_tenants/management/commands/all_tenants_command.py
@@ -42,9 +42,6 @@ class Command(BaseCommand):
         else:
             klass = load_command_class(app_name, command_args[1])
 
-        # Ugly, but works. Delete tenant_command from the argv, parse the schema manually
-        # and forward the rest of the arguments to the actual command being wrapped.
-
         schema_parser = argparse.ArgumentParser()
         schema_namespace, args = schema_parser.parse_known_args(command_args)
         print(args)

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -340,6 +340,10 @@ To run any command on an every schema, you can use the special ``all_tenants_com
 
     ./manage.py all_tenants_command loaddata
 
+If the command you need to run on all tenants should not be run on the public tenant, you can specify the ``--no-public`` flag which whill exclude the public tenant.
+
+.. code-block:: bash
+    ./ manage.py all_tenants_command --no-public loaddata
 
 
 create_tenant_superuser

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -343,7 +343,9 @@ To run any command on an every schema, you can use the special ``all_tenants_com
 If the command you need to run on all tenants should not be run on the public tenant, you can specify the ``--no-public`` flag which whill exclude the public tenant.
 
 .. code-block:: bash
-    ./ manage.py all_tenants_command --no-public loaddata
+
+    ./manage.py all_tenants_command --no-public loaddata
+
 
 
 create_tenant_superuser


### PR DESCRIPTION
From time to time we need to run commands on all tenants excluding the public tenant. An example of this might be rebuilding an Elasticsearch cache after a migration is executed. When we do this the vast majority of apps we rebuild are tenant specific and using the `all_tenants_command` fails as the public tenant does not have these tables.

I have added an extra `--no-public` flag to explicitly exclude the public schema from specific operations and cleaned up some of the jank that was in the management commands.

Appreciate your comments.