### PR TITLE
Remove deprecated url Imports from example projects

### DIFF
--- a/examples/tenant_multi_types/tenant_multi_types_tutorial/urls_public.py
+++ b/examples/tenant_multi_types/tenant_multi_types_tutorial/urls_public.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.urls import path
 from tenant_multi_types_tutorial.views import HomeView
 from django.contrib import admin
@@ -6,4 +6,4 @@ from django.contrib import admin
 urlpatterns = [
     path('', HomeView.as_view()),
     path('admin/', admin.site.urls),
-    ]
+]

--- a/examples/tenant_subfolder_tutorial/tenant_subfolder_tutorial/urls_public.py
+++ b/examples/tenant_subfolder_tutorial/tenant_subfolder_tutorial/urls_public.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.urls import path
 from tenant_subfolder_tutorial.views import HomeView
 from django.contrib import admin
@@ -6,4 +6,4 @@ from django.contrib import admin
 urlpatterns = [
     path('', HomeView.as_view()),
     path('admin/', admin.site.urls),
-    ]
+]

--- a/examples/tenant_tutorial/tenant_tutorial/urls_public.py
+++ b/examples/tenant_tutorial/tenant_tutorial/urls_public.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.urls import path
 from tenant_tutorial.views import HomeView
 from django.contrib import admin
@@ -6,4 +6,4 @@ from django.contrib import admin
 urlpatterns = [
     path('', HomeView.as_view()),
     path('admin/', admin.site.urls),
-    ]
+]


### PR DESCRIPTION
`django.conf.urls.url()` has been deprecated and removed in Django 4.0+, but it is still imported in all `urls_public.py` files in the example projects, hence causing an import error.