### PR TITLE
Don't GRANT permissions to sequences when using IDENTITY columns.

### DIFF
--- a/django_tenants/clone.py
+++ b/django_tenants/clone.py
@@ -59,6 +59,7 @@ DECLARE
   arec             RECORD;
   cnt              integer;
   cnt2             integer;
+  seq_cnt          integer;
   pos              integer;
   action           text := 'N/A';
   v_ret            text;
@@ -212,14 +213,14 @@ BEGIN
 
   -- Create sequences
   action := 'Sequences';
-  cnt := 0;
+  seq_cnt := 0;
   -- TODO: Find a way to make this sequence's owner is the correct table.
   FOR object IN
     SELECT sequence_name::text
       FROM information_schema.sequences
      WHERE sequence_schema = quote_ident(source_schema)
   LOOP
-    cnt := cnt + 1;
+    seq_cnt := seq_cnt + 1;
     IF ddl_only THEN
       RAISE INFO '%', 'CREATE SEQUENCE ' || quote_ident(dest_schema) || '.' || quote_ident(object) || ';';
     ELSE
@@ -270,7 +271,7 @@ BEGIN
 
     END IF;
   END LOOP;
-  RAISE NOTICE '   SEQUENCES cloned: %', LPAD(cnt::text, 5, ' ');
+  RAISE NOTICE '   SEQUENCES cloned: %', LPAD(seq_cnt::text, 5, ' ');
 
 -- Create tables
   action := 'Tables';
@@ -621,7 +622,7 @@ BEGIN
   LOOP
     BEGIN
       cnt := cnt + 1;
-      IF ddl_only THEN
+      IF ddl_only OR seq_cnt = 0 THEN
         RAISE INFO '%', arec.seq_ddl;
       ELSE
         EXECUTE arec.seq_ddl;


### PR DESCRIPTION
Fixes #802

Notes:

- see the issue for background analysis
- this patch seems like the easiest fix without refactoring the entire
  clone_schema() function!

Speculation:

I think that because IDENTITY columns use sequences internally (opposed
to creating sequences explicitly) information_schema doesn't contain
information about them anymore (resulting in seq_cnt = 0). However this
internal information is still present in pg_catalog which results in an
error when trying to grant the permissions.

Also possible that at the time the GRANT statement is executed the internal
sequences aren't created yet and they are only created only *AFTER* the entire
transaction is committed.

@tomturner this is the least invasive patch that I could figure out. Seems to work for me. I will try a bit more to reproduce with the upstream test suite but so far no luck.

Note: a new PyPI release would be awesome. 