### PR TITLE
Feature/get_executor hook

### DIFF
--- a/django_tenants/management/commands/migrate_schemas.py
+++ b/django_tenants/management/commands/migrate_schemas.py
@@ -2,6 +2,15 @@ from django_tenants.migration_executors import get_executor
 from django_tenants.utils import get_tenant_model, get_public_schema_name, schema_exists, get_tenant_database_alias, \
     has_multi_type_tenants, get_multi_type_database_field_name, get_tenant_migration_order
 from django_tenants.management.commands import SyncCommon
+from django.utils.module_loading import import_string
+from django.conf import settings
+
+
+GET_EXECUTOR_FUNCTION = getattr(settings, 'GET_EXECUTOR_FUNCTION', None)
+if GET_EXECUTOR_FUNCTION:
+    GET_EXECUTOR_FUNCTION = import_string(GET_EXECUTOR_FUNCTION)
+else:
+    GET_EXECUTOR_FUNCTION = get_executor
 
 
 class MigrateSchemasCommand(SyncCommon):
@@ -48,7 +57,7 @@ class MigrateSchemasCommand(SyncCommon):
         if self.sync_public and not self.schema_name:
             self.schema_name = self.PUBLIC_SCHEMA_NAME
 
-        executor = get_executor(codename=self.executor)(self.args, self.options)
+        executor = GET_EXECUTOR_FUNCTION(codename=self.executor)(self.args, self.options)
 
         if self.sync_public:
             executor.run_migrations(tenants=[self.PUBLIC_SCHEMA_NAME])

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -456,7 +456,7 @@ When set, ``django-tenants`` will set the search path only once per request. The
 Extra Set Tenant Method
 -----------------------
 
-Sometime you might want to do something special when you switch to another schema / tenant such as read replica.
+Sometimes you might want to do something special when you switch to another schema / tenant such as read replica.
 Add ``EXTRA_SET_TENANT_METHOD_PATH`` to the settings file and point a method.
 
 .. code-block:: python
@@ -473,6 +473,37 @@ example
 
     def extra_set_tenant_stuff(wrapper_class, tenant):
         pass
+
+
+Get Executor Function
+-----------------------
+
+Sometimes you might want to have some custom functionality with your migration executor.
+Add ``GET_EXECUTOR_FUNCTION`` to the settings file and point a method.
+
+.. code-block:: python
+
+    GET_EXECUTOR_FUNCTION = 'tenant_multi_types_tutorial.set_tenant_utils.get_custom_executor'
+
+The function
+~~~~~~~~~~
+
+The function takes 1 keyword argument (default=None) for the executor codename and returns a MigrationExector class.
+example
+
+.. code-block:: python
+    from .custom_migration_executors import CustomMigrationExecutor
+    from django_tenants.migrate_executors.standard import StandardExecutor
+
+    def get_custom_executor(codename=None):
+        codename = codename or os.environ.get('EXECUTOR', StandardExecutor.codename)
+
+        for klass in MigrationExecutor.__subclasses__():
+            if klass.codename == codename:
+                return klass
+
+        raise NotImplementedError('No executor with codename %s' % codename)
+
 
 Logging
 -------


### PR DESCRIPTION
**Problem**: I was writing my own `MigrationExecutor` class to handle soft deleted tenants but ran into an issue with injecting the executor into the `migrate_schemas` command. I could've imported the `migrate_schemas` management command into my project but it seemed like overkill.

**Solution**: Added a simple hook to override this with my own custom `get_executor` function.