### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/files.rst
+++ b/docs/files.rst
@@ -172,7 +172,7 @@ Just like with standard Django, the first template found will be returned.
 Specifying a different target directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-django-tenants supports simple Python string formatting for configuring the various path strings used throughout the configuration steps.  any occurances of ``%s`` in the path string will be replaced with the current tenant's ``schema_name`` during runtime.
+django-tenants supports simple Python string formatting for configuring the various path strings used throughout the configuration steps.  any occurrences of ``%s`` in the path string will be replaced with the current tenant's ``schema_name`` during runtime.
 
 This makes it possible to cater for more elaborate folder structures. Some examples are provided below:
 

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -105,7 +105,7 @@ You can set the the verbosity by overriding the ``get_verbosity`` method.
 
 Running tests faster
 --------------------
-Using the ``TenantTestCase`` can make running your tests really slow quite early in your project. This is due to the fact that it drops, recreates the test schema and runs migrations for every ``TenantTestCase`` you have. If you want to gain speed, there's a ``FastTenantTestCase`` where the test schema will be created and migrations ran only one time. The gain in speed is noticiable but be aware that by using this you will be perpertraiting state between your test cases, please make sure your they wont be affected by this.
+Using the ``TenantTestCase`` can make running your tests really slow quite early in your project. This is due to the fact that it drops, recreates the test schema and runs migrations for every ``TenantTestCase`` you have. If you want to gain speed, there's a ``FastTenantTestCase`` where the test schema will be created and migrations ran only one time. The gain in speed is noticeable but be aware that by using this you will be perpetrating state between your test cases, please make sure your they wont be affected by this.
 
 Running tests using ``TenantTestCase`` can start being a bottleneck once the number of tests grow. If you do not care that the state between tests is kept, an alternative is to use the class ``FastTenantTestCase``. Unlike ``TenantTestCase``, the test schema and its migrations will only be created and ran once. This is a significant improvement in speed coming at the cost of shared state.
 

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -340,7 +340,7 @@ To run any command on an every schema, you can use the special ``all_tenants_com
 
     ./manage.py all_tenants_command loaddata
 
-If the command you need to run on all tenants should not be run on the public tenant, you can specify the ``--no-public`` flag which whill exclude the public tenant.
+If the command you need to run on all tenants should not be run on the public tenant, you can specify the ``--no-public`` flag which will exclude the public tenant.
 
 .. code-block:: bash
 
@@ -369,7 +369,7 @@ The command ``create_tenant`` creates a new schema
 
 The argument are dynamic depending on the fields that are in the ``TenantMixin`` model.
 For example if you have a field in the ``TenantMixin`` model called company you will be able to set this using --company=MyCompany.
-If no argument are specified for a field then you be promted for the values.
+If no argument are specified for a field then you be prompted for the values.
 There is an additional argument of -s which sets up a superuser for that tenant.
 
 


### PR DESCRIPTION
There are small typos in:
- docs/files.rst
- docs/test.rst
- docs/use.rst

Fixes:
- Should read `will` rather than `whill`.
- Should read `prompted` rather than `promted`.
- Should read `perpetrating` rather than `perpertraiting`.
- Should read `occurrences` rather than `occurances`.
- Should read `noticeable` rather than `noticiable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md