### PR TITLE
Fix quotation marks being included in search path

### DIFF
--- a/django_tenants/postgresql_backend/introspection.py
+++ b/django_tenants/postgresql_backend/introspection.py
@@ -13,12 +13,15 @@ class DatabaseSchemaIntrospectionSearchPathContext:
 
     def __enter__(self):
         self.cursor.execute('SHOW search_path')
-        self.original_search_path = self.cursor.fetchone()[0].split(',')
+        self.original_search_path = [
+            search_path.strip().replace('"', '')
+            for search_path in self.cursor.fetchone()[0].split(',')
+        ]
         self.cursor.execute(f"SET search_path = '{self.connection.schema_name}'")
 
     def __exit__(self, *args, **kwargs):
         formatted_search_paths = ', '.join(
-            f"'{search_path.strip()}'"
+            f"'{search_path}'"
             for search_path in self.original_search_path
         )
         self.cursor.execute(f'SET search_path = {formatted_search_paths}')


### PR DESCRIPTION
[PostgreSQL version: 11.1]

Schema names containing underscores are wrapped in quotation marks by postgres when running `SHOW search_path`:
```
db=# SET search_path = 'country_BD';
SET

db=# SHOW search_path;
 search_path
--------------
 "country_BD"
(1 row)
```

Without the underscore, the quotation marks are not present:
```
db=# SET search_path = 'country';
SET

db=# SHOW search_path;
 search_path
-------------
 country
(1 row)
```

As a result, when a schema name contains an underscore, the search path restoration logic ends up adding quotes each time and table lookups stop working:
```
db=# SET search_path = 'country_A';
SET
db=# SHOW search_path;
 search_path
-------------
 "country_A"
(1 row)

db=# SET search_path = '"country_A"';
SET
db=# SHOW search_path;
   search_path
-----------------
 """country_A"""
(1 row)
```

This PR extends #693 to fix the issue.