### PR TITLE
Fix malformed link in docs

### DIFF
--- a/docs/involved.rst
+++ b/docs/involved.rst
@@ -3,4 +3,4 @@ Get Involved!
 =============
 Suggestions, bugs, ideas, patches, questions
 --------------------------------------------
-Are **highly** welcome! Feel free to write an issue for any feedback you have or send a pull request on `GitHub <https://github.com/django-tenants/django-tenants>`. :)
+Are **highly** welcome! Feel free to write an issue for any feedback you have or send a pull request on `GitHub <https://github.com/django-tenants/django-tenants>`_. :)


### PR DESCRIPTION
A minor formatting fix for the link on [this page](https://django-tenants.readthedocs.io/en/latest/involved.html):

<img width="753" alt="image" src="https://user-images.githubusercontent.com/861044/191984752-10eaf26a-e186-4be3-bf60-10ba7451b667.png">
