### PR TITLE
test cases: add a subfolder test case

### DIFF
--- a/django_tenants/test/cases.py
+++ b/django_tenants/test/cases.py
@@ -161,3 +161,21 @@ class FastTenantTestCase(TenantTestCase):
     def _fixture_teardown(self):
         if self.flush_data():
             super()._fixture_teardown()
+
+
+class SubfolderTenantTestCase(TenantTestCase):
+    """Adds a public tenant to support tests against TenantSubfolderMiddleware
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Set up public tenant
+        cls.public_tenant = get_tenant_model()(schema_name=get_public_schema_name())
+        cls.public_tenant.save()
+
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        cls.public_tenant.delete()

--- a/django_tenants/tests/test_subfolder_case.py
+++ b/django_tenants/tests/test_subfolder_case.py
@@ -1,0 +1,52 @@
+from django.test.client import RequestFactory
+from django.conf import settings
+
+from django_tenants.middleware import TenantSubfolderMiddleware
+from django_tenants.test.cases import SubfolderTenantTestCase
+
+
+class SubfolderTenantTestCase(SubfolderTenantTestCase):
+    """Testing use of SubfolderTenantTestCase to build testcases supporting
+    projects making use of TenantSubfolderMiddleware
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        settings.TENANT_SUBFOLDER_PREFIX = 'clients/'
+        self.factory = RequestFactory()
+        self.tsf = TenantSubfolderMiddleware(lambda r: r)
+
+    def test_tenant_routing(self):
+        """
+        Request path should not be altered.
+        """
+        request_url = '/clients/tenant.test.com/any/request/'
+        request = self.factory.get('/clients/tenant.test.com/any/request/')
+        self.tsf.process_request(request)
+
+        self.assertEqual(request.path_info, request_url)
+
+        # request.tenant should also have been set
+        self.assertEqual(request.tenant, self.tenant)
+
+    def test_public_schema_routing(self):
+        """
+        Request path should not be altered.
+        """
+        request_url = '/any/request/'
+        request = self.factory.get('/any/request/')
+        self.tsf.process_request(request)
+
+        self.assertEqual(request.path_info, request_url)
+
+        # request.tenant should also have been set
+        self.assertEqual(request.tenant, self.public_tenant)
+
+    def test_missing_tenant(self):
+        """
+        Request path should not be altered.
+        """
+        request = self.factory.get('/clients/not-found/any/request/')
+
+        with self.assertRaises(self.tsf.TENANT_NOT_FOUND_EXCEPTION):
+            self.tsf.process_request(request)


### PR DESCRIPTION
Hello,

First thank you for maintaining this project! we are using it successfully to migrate an existing app to multi tenancy and hope to contribute a little back.

This first PR is a small change we needed to make to use the TenantTestCase with an app setup with the TenantSubfolderMiddleware.

**Problem**: TenantSubfolderMiddleware requires a public tenant exists in the tenant model table, TenantTestCase does not setup a public tenant

**Solution**: add a SubfolderTenantTestCase which inherits from TenantTestCase and handle public tenant setup and teardown.

For testing I reused the tests from SubfolderRoutesTestCase but instead subclassing SubfolderTenantTestCase.

Looking forward to your feedback and suggestions, thank you for your time!