### PR TITLE
Introduce a new setting to specify a custom migrate command

### DIFF
--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -2,11 +2,14 @@ import sys
 
 from django.db import transaction
 
-from django.core.management.commands.migrate import Command as MigrateCommand
 from django.db.migrations.recorder import MigrationRecorder
 
 from django_tenants.signals import schema_migrated, schema_migrate_message
-from django_tenants.utils import get_public_schema_name, get_tenant_database_alias
+from django_tenants.utils import (
+    get_public_schema_name,
+    get_tenant_base_migrate_command_class,
+    get_tenant_database_alias,
+)
 
 
 def run_migrations(args, options, executor_codename, schema_name, tenant_type='',
@@ -50,7 +53,8 @@ def run_migrations(args, options, executor_codename, schema_name, tenant_type=''
     stderr.style_func = style_func
     if int(options.get('verbosity', 1)) >= 1:
         stdout.write(style.NOTICE("=== Starting migration"))
-    MigrateCommand(stdout=stdout, stderr=stderr).execute(*args, **options)
+    migrate_command_class = get_tenant_base_migrate_command_class()
+    migrate_command_class(stdout=stdout, stderr=stderr).execute(*args, **options)
 
     try:
         transaction.commit()

--- a/django_tenants/tests/test_utils.py
+++ b/django_tenants/tests/test_utils.py
@@ -1,5 +1,11 @@
 from django_tenants import utils
 from django_tenants.test.cases import TenantTestCase
+from django.core.management.commands.migrate import Command as MigrateCommand
+from django.test.utils import override_settings
+
+
+class CustomMigrateCommand(MigrateCommand):
+    pass
 
 
 class ConfigStringParsingTestCase(TenantTestCase):
@@ -20,3 +26,17 @@ class ConfigStringParsingTestCase(TenantTestCase):
             utils.parse_tenant_config_path("foo/%s/bar/"),
             "foo/{}/bar/".format(self.tenant.schema_name),
         )
+
+    def test_get_tenant_base_migrate_command_class_default(self):
+        self.assertEqual(
+            utils.get_tenant_base_migrate_command_class(),
+            MigrateCommand,
+        )
+
+    def test_get_tenant_base_migrate_command_class_custom(self):
+        command_path = 'django_tenants.tests.test_utils.CustomMigrateCommand'
+        with override_settings(TENANT_BASE_MIGRATE_COMMAND=command_path):
+            self.assertEqual(
+                utils.get_tenant_base_migrate_command_class(),
+                CustomMigrateCommand,
+            )

--- a/django_tenants/utils.py
+++ b/django_tenants/utils.py
@@ -37,6 +37,15 @@ def get_tenant_types():
     return getattr(settings, 'TENANT_TYPES', {})
 
 
+def get_tenant_base_migrate_command_class():
+    class_path = getattr(
+        settings,
+        'TENANT_BASE_MIGRATE_COMMAND',
+        'django.core.management.commands.migrate.Command',
+    )
+    return import_string(class_path)
+
+
 def has_multi_type_tenants():
     return getattr(settings, 'HAS_MULTI_TYPE_TENANTS', False)
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -257,6 +257,12 @@ Optional Settings
 
     A list of fields to order the tenant queryset by when migrating schemas.
 
+.. attribute:: TENANT_BASE_MIGRATE_COMMAND
+
+    :Default: ``django.core.management.commands.migrate.Command``
+
+    A custom ``migrate`` command class to replace the original one from Django. This is useful if you want to customize the ``migrate`` command to fit your needs.
+
 
 Tenant View-Routing
 -------------------


### PR DESCRIPTION
We want to customise a bit the `migrate` command in our project, but django-tenants doesn't offer any hooks to customise that currently.

This change introduces a new setting to customise the `migrate` command used by the `run_migrations()` function, defaulting to Django's (the way it works now).