### PR TITLE
Fix Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,13 +45,16 @@ setup(
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     install_requires=[


### PR DESCRIPTION
Add missing ones based on CI:
- Django 3.2 and 4.1 are supported by the package
- Python 3.10 is supported
