### PR TITLE
Execute tests in verbose mode

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -28,7 +28,7 @@ pushd dts_test_project
 EXECUTORS=( standard multiprocessing )
 
 for executor in "${EXECUTORS[@]}"; do
-    EXECUTOR=$executor PYTHONWARNINGS=d coverage run manage.py test django_tenants
+    EXECUTOR=$executor PYTHONWARNINGS=d coverage run manage.py test -v2 django_tenants
 done
 
 greenprint "===== START INTEGRATION TESTS ====="


### PR DESCRIPTION
in order to be able to inspect logs and see which ones were actually executed