### PR TITLE
Fix DeprecationWarning: invalid escape sequence '\.'

### DIFF
--- a/django_tenants/clone.py
+++ b/django_tenants/clone.py
@@ -5,7 +5,7 @@ from django.db.utils import ProgrammingError
 
 from django_tenants.utils import schema_exists
 
-CLONE_SCHEMA_FUNCTION = """
+CLONE_SCHEMA_FUNCTION = r"""
 -- https://github.com/denishpatel/pg-clone-schema/ rev 0d3b522
 -- https://github.com/tomturner/django-tenants/issues/322
 


### PR DESCRIPTION
See GitHub Action pytest output:
> export DATABASE_PASSWORD="testing"
  ./run_tests.sh
Database: localhost
postgres connection established
~/work/django-tenants/django-tenants/dts_test_project ~/work/django-tenants/django-tenants /home/runner/work/django-tenants/django-tenants/django_tenants/clone.py:8: DeprecationWarning: invalid escape sequence '\.'
  CLONE_SCHEMA_FUNCTION = """
Creating test database for alias 'default' ('test_dts_test_project')...
=== Starting migration