### PR TITLE
GitHub Actions: Add Python 3.11 to the testing

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         # always use latest Python b/c the point here is to test PostgreSQL compatibility
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         postgres-version: [11-bullseye, 12, 13, 14]
 
     steps:
@@ -50,11 +50,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["==3.1.*", "==3.2.*", "==4.0.*", "==4.1.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
-
+        exclude:  # Django v4.1 supports Python 3.11
+          - python-version: "3.11"
+            django-version: "==3.1.*"
+          - python-version: "3.11"
+            django-version: "==3.2.*"
+          - python-version: "3.11"
+            django-version: "==4.0.*"
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Add Django v4.1 running on Python 3.11 to the testing.
https://docs.djangoproject.com/en/4.1/faq/install/#what-python-version-can-i-use-with-django