### PR TITLE
hostname_from_request() not working well when frontend is in a differ…

### DIFF
--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -22,7 +22,14 @@ class TenantMainMiddleware(MiddlewareMixin):
         """ Extracts hostname from request. Used for custom requests filtering.
             By default removes the request's port and common prefixes.
         """
-        return remove_www(request.get_host().split(':')[0])
+
+        hostname = None
+        if 'HTTP_ORIGIN' in request.META:
+            hostname = request.META['HTTP_ORIGIN']    
+        else:
+             hostname = request.get_host()   
+         
+        return remove_www(hostname.replace("https://", "").split(':')[0])
 
     def get_tenant(self, domain_model, hostname):
         domain = domain_model.objects.select_related('tenant').get(domain=hostname)


### PR DESCRIPTION
Fixing #971
This PR adds to django-tenants the capability of determining the tenant when the request comes from an app frontend that is hosted in a server that is not the same as backend's. 

**Crurrent Behavior**: the frontend is pure html+css+js and backend is DRF+django-tenants. So when a request comes, django-tenants redirects to the public schema because the method hostname_from_request() is only returning the destination host from the request. It should redirect to the tenant schema.

**The Fix**: consists in getting the hostname from the HTTP_ORIGIN header, only recur to request.get_host() if the first fails.