### PR TITLE
Use netcat-traditional instead of netcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN mkdir /code
 VOLUME /code
 WORKDIR /code
 COPY requirements.txt /code/
-RUN apt-get update && apt-get -y install postgresql libpq-dev postgresql-client postgresql-client-common python3-pip git netcat
+RUN apt-get update && apt-get -y install postgresql libpq-dev postgresql-client postgresql-client-common python3-pip git netcat-traditional
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /code/


### PR DESCRIPTION
Use netcat-traditional package because of the following error (when trying to build docker):
 ```
=> ERROR [django-tenants-test 5/7] RUN apt-get update && apt-get -y install postgresql libpq-dev postgresql-client postgresql-client-common python3-pip git netcat                        4.5s
------                                                                                                                                                                                          
 > [django-tenants-test 5/7] RUN apt-get update && apt-get -y install postgresql libpq-dev postgresql-client postgresql-client-common python3-pip git netcat:                                   
0.305 Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]                                                                                                                            
0.398 Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]                                                                                                                   
0.432 Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]                                                                                                         
0.546 Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8906 kB]                                                                                                                 
2.266 Get:5 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [6408 B]
2.267 Get:6 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [65.8 kB]
3.260 Fetched 9229 kB in 3s (2981 kB/s)
3.260 Reading package lists...
3.781 Reading package lists...
4.286 Building dependency tree...
4.430 Reading state information...
4.436 Package netcat is a virtual package provided by:
4.436   netcat-openbsd 1.219-1
4.436   netcat-traditional 1.10-47
4.436 
4.439 E: Package 'netcat' has no installation candidate
------
failed to solve: process "/bin/sh -c apt-get update && apt-get -y install postgresql libpq-dev postgresql-client postgresql-client-common python3-pip git netcat" did not complete successfully: exit code: 100
```