### PR TITLE
return exception error

### DIFF
--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -43,8 +43,7 @@ class TenantMainMiddleware(MiddlewareMixin):
         try:
             tenant = self.get_tenant(domain_model, hostname)
         except domain_model.DoesNotExist:
-            self.no_tenant_found(request, hostname)
-            return
+            return self.no_tenant_found(request, hostname)
 
         tenant.domain_url = hostname
         request.tenant = tenant


### PR DESCRIPTION
if self.no_tenant_found get exception then if should return so we can catch the error and able to return proper response to client or other server.