### PR TITLE
Pass arguments to subcommand when using call_comand and tenant_command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.9
+FROM python:3.10
 #ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 VOLUME /code
 WORKDIR /code
 COPY requirements.txt /code/
-RUN apt-get update && apt-get -y install postgresql libpq-dev postgresql-client postgresql-client-common python3-pip git netcat
+RUN apt-get update && apt-get -y install postgresql libpq-dev postgresql-client postgresql-client-common python3-pip git netcat-traditional
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /code/

--- a/django_tenants/management/commands/tenant_command.py
+++ b/django_tenants/management/commands/tenant_command.py
@@ -49,13 +49,11 @@ class Command(InteractiveTenantOption, BaseCommand):
     def handle(self, *args, **options):
         tenant = self.get_tenant_from_options_or_interactive(**options)
         connection.set_tenant(tenant)
+        options.pop('schema_name', None)
 
         # options come including {"command_name": ["x", "y"]}
-        # in case multiple arguments are passed.
+        # Because command_name argument has nargs='+', thus it is always a list of strings
 
-        command_name = options.pop("command_name")
+        subcommand_name, *subcommand_options = options.pop("command_name")
 
-        if isinstance(command_name, list):
-            call_command(command_name[0], *command_name[1:])
-        else:
-            call_command(*args, **options)
+        call_command(subcommand_name, *subcommand_options, **options)

--- a/django_tenants/management/commands/tenant_command.py
+++ b/django_tenants/management/commands/tenant_command.py
@@ -12,7 +12,8 @@ class Command(InteractiveTenantOption, BaseCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
 
-        parser.add_argument('command_name', nargs='+', help='The command name you want to run')
+        parser.add_argument('command_name', nargs=argparse.ONE_OR_MORE, help='The command name you want to run')
+        parser.add_argument('command_options', nargs=argparse.REMAINDER, help='The command options')
 
     def run_from_argv(self, argv):
         """
@@ -51,9 +52,10 @@ class Command(InteractiveTenantOption, BaseCommand):
         connection.set_tenant(tenant)
         options.pop('schema_name', None)
 
-        # options come including {"command_name": ["x", "y"]}
+        # options come including {"command_name": ["x", "y"], "command_options": ["--w=1", "--z=2"]}
         # Because command_name argument has nargs='+', thus it is always a list of strings
 
         subcommand_name, *subcommand_options = options.pop("command_name")
+        subcommand_options += options.pop("command_options")
 
         call_command(subcommand_name, *subcommand_options, **options)

--- a/django_tenants/tests/test_commands.py
+++ b/django_tenants/tests/test_commands.py
@@ -1,4 +1,5 @@
 import io
+import json
 
 from django.core.management import call_command
 
@@ -12,25 +13,24 @@ class TenantCommandTestCase(FastTenantTestCase):
         DummyModel(name="Schemas are").save()
         DummyModel(name="awesome!").save()
 
-        indented_dump_data = '\n'.join([
-            '[',
-            '{',
-            '    "model": "dts_test_app.dummymodel",',
-            '    "pk": 1,',
-            '    "fields": {',
-            '        "name": "Schemas are"',
-            '    }',
-            '},',
-            '{',
-            '    "model": "dts_test_app.dummymodel",',
-            '    "pk": 2,',
-            '    "fields": {',
-            '        "name": "awesome!"',
-            '    }',
-            '}',
-            ']',
-            '',
-        ])
+        dump_data = [
+            {
+                "model": "dts_test_app.dummymodel",
+                "pk": 1,
+                "fields": {
+                    "name": "Schemas are"
+                }
+            },
+            {
+                "model": "dts_test_app.dummymodel",
+                "pk": 2,
+                "fields": {
+                    "name": "awesome!"
+                }
+            }
+        ]
+        # json.dump has extra level of indentation comparing to dumpdata, so we remove it
+        indented_dump_data = json.dumps(dump_data, indent=4).replace('\n    ', '\n')+'\n'
 
         out = io.StringIO()
         call_command(

--- a/django_tenants/tests/test_commands.py
+++ b/django_tenants/tests/test_commands.py
@@ -1,0 +1,47 @@
+import io
+
+from django.core.management import call_command
+
+from django_tenants.test.cases import FastTenantTestCase
+from dts_test_app.models import DummyModel
+
+
+class TenantCommandTestCase(FastTenantTestCase):
+
+    def test_pass_arguments_to_subcommand(self):
+        DummyModel(name="Schemas are").save()
+        DummyModel(name="awesome!").save()
+
+        indented_dump_data = '\n'.join([
+            '[',
+            '{',
+            '    "model": "dts_test_app.dummymodel",',
+            '    "pk": 1,',
+            '    "fields": {',
+            '        "name": "Schemas are"',
+            '    }',
+            '},',
+            '{',
+            '    "model": "dts_test_app.dummymodel",',
+            '    "pk": 2,',
+            '    "fields": {',
+            '        "name": "awesome!"',
+            '    }',
+            '}',
+            ']',
+            '',
+        ])
+
+        out = io.StringIO()
+        call_command(
+            'tenant_command',
+            'dumpdata',
+            'dts_test_app.DummyModel',
+            '--indent=4',
+            schema=self.tenant.schema_name,
+            stdout=out,
+        )
+        self.assertEqual(
+            out.getvalue(),  # test that stdout is passed
+            indented_dump_data  # test that indent is passed
+        )


### PR DESCRIPTION
Fixes #989 