### PR TITLE
Add Django 5.0 and Python 3.12, remove 3.1, 4.0 and Python 3.8

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -60,17 +60,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        django-version: ["==3.1.*", "==3.2.*", "==4.0.*", "==4.1.*", "==4.2.*"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        django-version: ["==3.2.*", "==4.1.*", "==4.2.*", "==5.0.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
         exclude:  # Django v4.1 supports Python 3.11
-          - python-version: "3.11"
-            django-version: "==3.1.*"
+          - python-version: "3.9"
+            django-version: "==5.0.*"
           - python-version: "3.11"
             django-version: "==3.2.*"
-          - python-version: "3.11"
-            django-version: "==4.0.*"
+          - python-version: "3.12"
+            django-version: "==3.2.*"
+          - python-version: "3.12"
+            django-version: "==4.1.*"
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        pip install psycopg2 coverage
+        pip install psycopg2 coverage setuptools
         pip install Django${{ matrix.django-version }}
         python setup.py develop
 

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -60,17 +60,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        django-version: ["==3.2.*", "==4.1.*", "==4.2.*", "==5.0.*"]
+        python-version: ["3.10", "3.11", "3.12"]
+        django-version: ["==4.1.*", "==4.2.*", "==5.0.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
-        exclude:  # Django v4.1 supports Python 3.11
-          - python-version: "3.9"
-            django-version: "==5.0.*"
-          - python-version: "3.11"
-            django-version: "==3.2.*"
-          - python-version: "3.12"
-            django-version: "==3.2.*"
+        exclude:
           - python-version: "3.12"
             django-version: "==4.1.*"
     steps:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-__version__ = "3.5.0"
+__version__ = "3.6.0"
 
 setup(
     name='django-tenants',
@@ -41,11 +41,6 @@ setup(
         'Environment :: Web Environment',
         'License :: OSI Approved :: MIT License',
         'Framework :: Django',
-        'Framework :: Django :: 2.1',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
-        'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -57,7 +58,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     install_requires=[
-        'Django >=2.1,<4.3',
+        'Django >=2.1,<5.1',
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Update the dependencies to include the the latest Django release
Add it, and Python 3.12, to the test runs and remove some old (unsupported) versions from the test matrix.