### PR TITLE
Return tenant delete result

### DIFF
--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -159,7 +159,7 @@ class TenantMixin(models.Model):
         auto_drop_schema set to True.
         """
         self._drop_schema(force_drop)
-        super().delete(*args, **kwargs)
+        return super().delete(*args, **kwargs)
 
     def create_schema(self, check_if_exists=False, sync_schema=True,
                       verbosity=1):


### PR DESCRIPTION
The returned value from `.delete()` is quite useful for showing what related objects were deleted, so I think it would be nice to return it from `TenantMixin` as well!