### PR TITLE
Use psycopg 3 instead of 2 for testing

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -24,14 +24,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Django
-      run: |
-        # always use latest Django b/c the point here is to test PostgreSQL compatibility
-        pip install Django
-
     - name: Install Python dependencies
       run: |
-        pip install psycopg2 coverage setuptools
+        pip install -r requirements.txt
+        pip install setuptools
+        # always use latest Django b/c the point here is to test PostgreSQL compatibility
+        pip install Django
         python setup.py develop
 
     - name: Create database
@@ -67,7 +65,8 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        pip install psycopg2 coverage setuptools
+        pip install -r requirements.txt
+        pip install setuptools
         pip install Django${{ matrix.django-version }}
         python setup.py develop
 

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -190,7 +190,7 @@ class TenantDataAndSettingsTest(BaseTestCase):
         DummyModel(name="awesome!").save()
 
         # switch temporarily to tenant2's path
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(3):
             with tenant_context(tenant2):
                 # add some data, 3 DummyModels for tenant2
                 DummyModel(name="Man,").save()
@@ -198,11 +198,11 @@ class TenantDataAndSettingsTest(BaseTestCase):
                 DummyModel(name="is great!").save()
 
         # we should be back to tenant1's path, test what we have
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.assertEqual(2, DummyModel.objects.count())
 
         # switch back to tenant2's path
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             with tenant_context(tenant2):
                 self.assertEqual(3, DummyModel.objects.count())
 
@@ -229,8 +229,7 @@ class TenantDataAndSettingsTest(BaseTestCase):
             connection.set_tenant(tenant1)
 
         # switch temporarily to tenant2's path
-        # 1 query to set search path + 3 to save data
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             with tenant_context(tenant2):
                 DummyModel(name="Man,").save()
                 DummyModel(name="testing").save()
@@ -240,16 +239,14 @@ class TenantDataAndSettingsTest(BaseTestCase):
         with self.assertNumQueries(0):
             connection.set_tenant(tenant1)
 
-        # 1 set search path + 1 count
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.assertEqual(0, DummyModel.objects.count())
 
         # 0 queries as search path not set here
         with self.assertNumQueries(0):
             connection.set_tenant(tenant2)
 
-        # 1 set search path + 1 count
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.assertEqual(3, DummyModel.objects.count())
 
         self.created = [domain2, domain1, tenant2, tenant1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Django==5.1.3
 psycopg>=3.2.1,<3.3
 gunicorn==23.0.0
 coverage


### PR DESCRIPTION
NOTE: not sure if the number of queries has changed, need to take a deeper look into it. 

Also found this bit of useful information: https://learndjango.com/tutorials/psycopg3-binary-and-django-42-installation-quick-t


WARNING: this commit forces pip to use requirements.txt in CI 

WARNING: remove Django from requirements.txt b/c version is explicitly configured in CI. For local development we can use whatever version we want (will usually be the latest anyway).