### PR TITLE
Add numeric tenant selection to tenant_command

### DIFF
--- a/django_tenants/management/commands/__init__.py
+++ b/django_tenants/management/commands/__init__.py
@@ -95,12 +95,25 @@ https://django-tenants.readthedocs.org/en/latest/use.html#creating-a-tenant""")
             while True:
                 tenant_schema = input("Enter Tenant Schema ('?' to list schemas): ")
                 if tenant_schema == '?':
-                    print('\n'.join(["%s - %s" % (t.schema_name, t.get_primary_domain()) for t in all_tenants]))
+                    print('\n'.join(["%i) %s - %s" % (t.schema_name, t.get_primary_domain()) for i, t in enumerate(all_tenants, start=1)]))
                 else:
                     break
 
-        if tenant_schema not in [t.schema_name for t in all_tenants]:
+        tenant_schema_index = 0
+        tenant_schema_index_is_valid = False
+
+        try:
+            tenant_schema_index = int(tenant_schema) - 1
+        except ValueError:
+            pass
+        else:
+            tenant_schema_index_is_valid = 0 < tenant_schema_index <= len(all_tenants) 
+
+        if tenant_schema not in [t.schema_name for t in all_tenants] and not tenant_schema_index_is_valid:
             raise CommandError("Invalid tenant schema, '%s'" % (tenant_schema,))
+
+        if tenant_schema_index_is_valid:
+            return all_tenants[tenant_schema_index]
 
         return TenantModel.objects.get(schema_name=tenant_schema)
 

--- a/django_tenants/management/commands/__init__.py
+++ b/django_tenants/management/commands/__init__.py
@@ -95,7 +95,7 @@ https://django-tenants.readthedocs.org/en/latest/use.html#creating-a-tenant""")
             while True:
                 tenant_schema = input("Enter Tenant Schema ('?' to list schemas): ")
                 if tenant_schema == '?':
-                    print('\n'.join(["%i) %s - %s" % (t.schema_name, t.get_primary_domain()) for i, t in enumerate(all_tenants, start=1)]))
+                    print('\n'.join(["%i) %s - %s" % (i, t.schema_name, t.get_primary_domain()) for i, t in enumerate(all_tenants, start=1)]))
                 else:
                     break
 


### PR DESCRIPTION
Often I have something on the clipboard I need to paste into the CLI and needing to manually copy and paste the schema name into the `Enter Tenant Schema ('?' to list schemas):` prompt is frustrating.

I've added functionality that prepends the current tenant schema listing with an index, so that one can just simply type the number of the tenant they wish to execute the command on and it will do so.

It looks like this:

```
Enter Tenant Schema ('?' to list schemas): ?
1) public - public.example.com
2) apple_1659236828 - apple.example.com
3) orange_1659735437 - orange.example.com
Enter Tenant Schema ('?' to list schemas): 2
```