### PR TITLE
Fix error upon creating tenant from public schema

### DIFF
--- a/django_tenants/urlresolvers.py
+++ b/django_tenants/urlresolvers.py
@@ -8,7 +8,10 @@ from django.utils.functional import lazy
 from django_tenants.utils import (
     get_tenant_domain_model,
     get_subfolder_prefix,
-    clean_tenant_url, has_multi_type_tenants, get_tenant_types,
+    clean_tenant_url,
+    has_multi_type_tenants,
+    get_tenant_types,
+    get_public_schema_name,
 )
 
 
@@ -28,9 +31,13 @@ class TenantPrefixPattern:
         _DomainModel = get_tenant_domain_model()
         subfolder_prefix = get_subfolder_prefix()
         try:
+            if hasattr(connection.tenant, "domain_subfolder"):
+                domain_subfolder = connection.tenant.domain_subfolder
+            else:
+                domain_subfolder = get_public_schema_name()
             domain = _DomainModel.objects.get(
                 tenant__schema_name=connection.schema_name,
-                domain=connection.tenant.domain_subfolder,
+                domain=domain_subfolder,
             )
             return (
                 "{}/{}/".format(subfolder_prefix, domain.domain)


### PR DESCRIPTION
I faced the same issue as in https://github.com/django-tenants/django-tenants/issues/1005 and this fixed it for me. So I'm hoping we can get this merged so I can also use this in my production instance. 


For me this issue arose when I tried to create a new Tenant from the admin, via a custom TenantRequest model and having an action in the admin where I can either reject or accept such requests. It would create the tenant successfully, but when rendering the response it would fail with the error mentioned in issue #1005 