### PR TITLE
Add tenant attribute to request object

### DIFF
--- a/django_tenants/test/client.py
+++ b/django_tenants/test/client.py
@@ -14,7 +14,10 @@ class BaseTenantRequestFactory:
     def generic(self, *args, **kwargs):
         if "HTTP_HOST" not in kwargs:
             kwargs["HTTP_HOST"] = self.tenant.get_primary_domain().domain
-        return super().generic(*args, **kwargs)
+        request = super().generic(*args, **kwargs)
+        # Assign the tenant to the request object
+        request.tenant = self.tenant
+        return request
 
 
 class TenantRequestFactory(BaseTenantRequestFactory, RequestFactory):


### PR DESCRIPTION
Add the `tenant` attribute to `request` objects generated by `TenantRequestFactory`, simulating what all the middleware options do.

Closes #1040 