### PR TITLE
Add Django v5.1 to the testing

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["==4.2.*", "==5.0.*", "==5.1rc1"]
+        django-version: ["==4.2.*", "==5.0.*", "==5.1.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
     steps:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix: # https://www.postgresql.org/docs/release
         # always use latest Python b/c the point here is to test PostgreSQL compatibility
-        python-version: [3.x]
+        python-version: ["3.12"]
         postgres-version: [13, 14, 15, 16]
 
     steps:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["==4.2.*", "==5.0.*", "==5.1b1"]
+        django-version: ["==4.2.*", "==5.0.*", "==5.1rc1"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
     steps:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      matrix:
+      matrix: # https://www.postgresql.org/docs/release
         # always use latest Python b/c the point here is to test PostgreSQL compatibility
         python-version: ["3.12"]
-        postgres-version: [12, 13, 14, 15, 16]
+        postgres-version: [13, 14, 15, 16]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         # always use latest Python b/c the point here is to test PostgreSQL compatibility
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         postgres-version: [12, 13, 14, 15, 16]
 
     steps:
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        pip install psycopg2 coverage
+        pip install psycopg2 coverage setuptools
         python setup.py develop
 
     - name: Create database
@@ -54,12 +54,9 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
-        django-version: ["==4.1.*", "==4.2.*", "==5.0.*"]
+        django-version: ["==4.2.*", "==5.0.*", "==5.1b1"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
-        exclude:
-          - python-version: "3.12"
-            django-version: "==4.1.*"
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix: # https://www.postgresql.org/docs/release
         # always use latest Python b/c the point here is to test PostgreSQL compatibility
-        python-version: ["3.12"]
+        python-version: [3.x]
         postgres-version: [13, 14, 15, 16]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -41,19 +41,19 @@ setup(
         'Environment :: Web Environment',
         'License :: OSI Approved :: MIT License',
         'Framework :: Django',
-        'Framework :: Django :: 4.0',
-        'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     install_requires=[
-        'Django >=2.1,<5.1',
+        'Django >=2.1,<5.2',
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Test Django v5.1 which was released on August 7th, 2024.
* https://docs.djangoproject.com/en/stable/releases/5.1
* https://pypi.org/project/Django/#history
* Django v5.1 drops support for Postgres v12
    * https://docs.djangoproject.com/en/stable/releases/5.1/#dropped-support-for-postgresql-12