### PR TITLE
Fix delete_tenant command

### DIFF
--- a/django_tenants/management/commands/delete_tenant.py
+++ b/django_tenants/management/commands/delete_tenant.py
@@ -33,17 +33,17 @@ class Command(InteractiveTenantOption, BaseCommand):
             while len(result) < 1 or result.lower() not in ["yes", "no"]:
                 result = input("Please answer yes or no: ")
                 if result.lower() == "yes":
-                    self.delete_tenant(schema_name)
+                    self.delete_tenant(tenant)
                 elif result.lower() == "no":
                     self.stderr.write("Canceled")
         else:
-            self.delete_tenant(schema_name)
+            self.delete_tenant(tenant)
 
-    def delete_tenant(self, schema_name):
-        self.print_info(f"Deleting '{schema_name}'" )
+    def delete_tenant(self, tenant):
+        self.print_info(f"Deleting '{tenant.schema_name}'" )
         tenant.auto_drop_schema = True
         tenant.delete()
-        self.print_info(f"Deleted '{schema_name}'")
+        self.print_info(f"Deleted '{tenant.schema_name}'")
 
     def print_warning(self, message):
         self.stderr.write(f"\033[91m{message}\033[0m")


### PR DESCRIPTION
Was facing an error in the `delete_tenant` command, since the tenant was not being passed to the `Command.delete_tenant` method

```
Traceback (most recent call last):
  File "/Users/parth/iden/bastion/manage.py", line 22, in <module>
    main()
  File "/Users/parth/iden/bastion/manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/Users/parth/iden/bastion/.venv/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/Users/parth/iden/bastion/.venv/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/parth/iden/bastion/.venv/lib/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/parth/iden/bastion/.venv/lib/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/parth/iden/bastion/.venv/lib/python3.11/site-packages/django_tenants/management/commands/delete_tenant.py", line 36, in handle
    self.delete_tenant(schema_name)
  File "/Users/parth/iden/bastion/.venv/lib/python3.11/site-packages/django_tenants/management/commands/delete_tenant.py", line 44, in delete_tenant
    tenant.auto_drop_schema = True
    ^^^^^^
NameError: name 'tenant' is not defined
```

Fixed it by passing the `tenant` instead of the `schema_name`