### PR TITLE
Send a signal before migrations run

### DIFF
--- a/django_tenants/migration_executors/base.py
+++ b/django_tenants/migration_executors/base.py
@@ -4,7 +4,7 @@ from django.db import transaction
 
 from django.db.migrations.recorder import MigrationRecorder
 
-from django_tenants.signals import schema_migrated, schema_migrate_message
+from django_tenants.signals import schema_migrated, schema_migrate_message, schema_pre_migration
 from django_tenants.utils import (
     get_public_schema_name,
     get_tenant_base_migrate_command_class,
@@ -38,6 +38,8 @@ def run_migrations(args, options, executor_codename, schema_name, tenant_type=''
         )
         schema_migrate_message.send(run_migrations, message=signal_message)
         return message
+
+    schema_pre_migration.send(run_migrations, schema_name=schema_name)
 
     connection = connections[options.get('database', get_tenant_database_alias())]
     connection.set_schema(schema_name, tenant_type=tenant_type, include_public=False)

--- a/django_tenants/signals.py
+++ b/django_tenants/signals.py
@@ -26,6 +26,15 @@ Sent after migration has finished on a schema
 Argument Required = schema_name
 """
 
+
+schema_pre_migration = Signal()
+schema_pre_migration.__doc__ = """
+Sent before migrations start on a schema
+
+Argument Required = schema_name
+"""
+
+
 schema_migrate_message = Signal()
 schema_migrate_message.__doc__ = """
 Sent when a message is generated in run migration

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -8,7 +8,7 @@ from django.db import connection, transaction
 from django.test.utils import override_settings
 
 from django_tenants.clone import CloneSchema
-from django_tenants.signals import schema_migrated, schema_migrate_message
+from django_tenants.signals import schema_migrated, schema_migrate_message, schema_pre_migration
 from dts_test_app.models import DummyModel, ModelWithFkToPublicUser
 
 from django_tenants.migration_executors import get_executor
@@ -685,10 +685,15 @@ class SchemaMigratedSignalTest(BaseTestCase):
         Public schema always gets migrated in the current process,
         even with executor multiprocessing.
         """
-        with catch_signal(schema_migrated) as handler:
+        with catch_signal(schema_migrated) as handler_post, catch_signal(schema_pre_migration) as handler_pre:
             self.sync_shared()
 
-        handler.assert_called_once_with(
+        handler_pre.assert_called_once_with(
+            schema_name=get_public_schema_name(),
+            sender=mock.ANY,
+            signal=schema_pre_migration,
+        )
+        handler_post.assert_called_once_with(
             schema_name=get_public_schema_name(),
             sender=mock.ANY,
             signal=schema_migrated,
@@ -702,11 +707,16 @@ class SchemaMigratedSignalTest(BaseTestCase):
         executor = get_executor()
 
         tenant = get_tenant_model()(schema_name='test')
-        with catch_signal(schema_migrated) as handler:
+        with catch_signal(schema_migrated) as handler_post, catch_signal(schema_pre_migration) as handler_pre:
             tenant.save()
 
         if executor == 'simple':
-            handler.assert_called_once_with(
+            handler_pre.assert_called_once_with(
+                schema_name='test',
+                sender=mock.ANY,
+                signal=schema_pre_migration
+            )
+            handler_post.assert_called_once_with(
                 schema_name='test',
                 sender=mock.ANY,
                 signal=schema_migrated
@@ -714,7 +724,8 @@ class SchemaMigratedSignalTest(BaseTestCase):
         elif executor == 'multiprocessing':
             # migrations run in a different process, therefore signal
             # will get sent in a different process as well
-            handler.assert_not_called()
+            handler_post.assert_not_called()
+            handler_pre.assert_not_called()
 
         domain = get_tenant_domain_model()(tenant=tenant, domain='something.test.com')
         domain.save()
@@ -731,11 +742,22 @@ class SchemaMigratedSignalTest(BaseTestCase):
         domain.save()
 
         # test the signal gets called when running migrate
-        with catch_signal(schema_migrated) as handler:
+        with catch_signal(schema_migrated) as handler_post, catch_signal(schema_pre_migration) as handler_pre:
             call_command('migrate_schemas', interactive=False, verbosity=0)
 
         if executor == 'simple':
-            handler.assert_has_calls([
+            handler_pre.assert_has_calls([
+                mock.call(
+                    schema_name=get_public_schema_name(),
+                    sender=mock.ANY,
+                    signal=schema_pre_migration,
+                ),
+                mock.call(
+                    schema_name='test',
+                    sender=mock.ANY,
+                    signal=schema_pre_migration)
+            ])
+            handler_post.assert_has_calls([
                 mock.call(
                     schema_name=get_public_schema_name(),
                     sender=mock.ANY,
@@ -748,7 +770,12 @@ class SchemaMigratedSignalTest(BaseTestCase):
             ])
         elif executor == 'multiprocessing':
             # public schema gets migrated in the current process, always
-            handler.assert_called_once_with(
+            handler_pre.assert_called_once_with(
+                schema_name=get_public_schema_name(),
+                sender=mock.ANY,
+                signal=schema_pre_migration,
+            )
+            handler_post.assert_called_once_with(
                 schema_name=get_public_schema_name(),
                 sender=mock.ANY,
                 signal=schema_migrated,
@@ -797,10 +824,22 @@ class MigrationOrderTestTest(BaseTestCase):
         )
 
         # test the signal gets called when running migrate
-        with catch_signal(schema_migrated) as handler:
+        with catch_signal(schema_migrated) as handler_post, catch_signal(schema_pre_migration) as handler_pre:
             call_command("migrate_schemas", interactive=False, verbosity=0)
 
-        handler.assert_has_calls(
+        handler_pre.assert_has_calls(
+            [
+                mock.call(
+                    schema_name=get_public_schema_name(),
+                    sender=mock.ANY,
+                    signal=schema_pre_migration,
+                ),
+                mock.call(schema_name="xtest", sender=mock.ANY, signal=schema_pre_migration),
+                mock.call(schema_name="test", sender=mock.ANY, signal=schema_pre_migration),
+            ]
+        )
+
+        handler_post.assert_has_calls(
             [
                 mock.call(
                     schema_name=get_public_schema_name(),

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -133,6 +133,8 @@ There are number of signals
 
 ```schema_migrated``` will get called once migrations finish running for a schema.
 
+```schema_pre_migration``` will get called just before migrations start running for a schema.
+
 ```schema_migrate_message``` will get called after each migration with the message of the migration. This signal is very useful when for process / status bars.
 
 Example
@@ -152,6 +154,12 @@ Example
         client = kwargs['tenant']
 
         # send email to client to as tenant is ready to use
+
+    @receiver(schema_pre_migration, sender=run_migrations)
+    def handle_schema_pre_migration(sender, **kwargs):
+        schema_name = kwargs['schema_name']
+
+        # write some logs
 
     @receiver(schema_migrated, sender=run_migrations)
     def handle_schema_migrated(sender, **kwargs):


### PR DESCRIPTION
Django itself has signals pre/post migrations (https://github.com/django/django/blob/main/django/db/models/signals.py#L53), so this introduces the pre signal for django-tenants. We already have `schema_migrated` which is the post signal