### PR TITLE
middleware - Add custom view support for default view tenant not found

### DIFF
--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -3,6 +3,7 @@ from django.core.exceptions import DisallowedHost
 from django.db import connection
 from django.http import Http404
 from django.urls import set_urlconf
+from django.utils.module_loading import import_string
 from django.utils.deprecation import MiddlewareMixin
 
 from django_tenants.utils import remove_www, get_public_schema_name, get_tenant_types, \
@@ -54,7 +55,17 @@ class TenantMainMiddleware(MiddlewareMixin):
     def no_tenant_found(self, request, hostname):
         """ What should happen if no tenant is found.
         This makes it easier if you want to override the default behavior """
-        if hasattr(settings, 'SHOW_PUBLIC_IF_NO_TENANT_FOUND') and settings.SHOW_PUBLIC_IF_NO_TENANT_FOUND:
+        if hasattr(settings, 'DEFAULT_NOT_FOUND_TENANT_VIEW'):
+            view_path = settings.DEFAULT_NOT_FOUND_TENANT_VIEW
+            view = import_string(view_path)
+            if hasattr(view, 'as_view'):
+                response = view.as_view()(request)
+            else:
+                response = view(request)
+            if hasattr(response, 'render'):
+                response.render()
+            return response
+        elif hasattr(settings, 'SHOW_PUBLIC_IF_NO_TENANT_FOUND') and settings.SHOW_PUBLIC_IF_NO_TENANT_FOUND:
             self.setup_url_routing(request=request, force_public=True)
         else:
             raise self.TENANT_NOT_FOUND_EXCEPTION('No tenant for hostname "%s"' % hostname)

--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -44,8 +44,8 @@ class TenantMainMiddleware(MiddlewareMixin):
         try:
             tenant = self.get_tenant(domain_model, hostname)
         except domain_model.DoesNotExist:
-            self.no_tenant_found(request, hostname)
-            return
+            default_tenant = self.no_tenant_found(request, hostname)
+            return default_tenant
 
         tenant.domain_url = hostname
         request.tenant = tenant

--- a/django_tenants/tests/test_middleware.py
+++ b/django_tenants/tests/test_middleware.py
@@ -1,7 +1,18 @@
 from django.http import HttpResponseNotFound
+from django.test.utils import override_settings
+from django.views import View
 
 from django_tenants.test.cases import FastTenantTestCase
 from django_tenants.test.client import TenantClient
+
+
+def custom_not_found_view(request):
+    return HttpResponseNotFound("Custom 404 Not Found")
+
+
+class CustomNotFoundView(View):
+    def get(self, request):
+        return HttpResponseNotFound("Custom 404 Not Found")
 
 
 class InvalidHostname(FastTenantTestCase):
@@ -22,3 +33,25 @@ class InvalidHostname(FastTenantTestCase):
         response = self.client.get('/')
 
         self.assertIsInstance(response, HttpResponseNotFound)
+
+
+class ShowPublicNoTenantFound(FastTenantTestCase):
+    @classmethod
+    def get_test_tenant_domain(cls):
+        return 'tenant.fast-test.com'
+
+    def setUp(self):
+        super().setUp()
+        self.client = TenantClient(self.tenant)
+
+    @override_settings(DEFAULT_NOT_FOUND_TENANT_VIEW='django_tenants.tests.test_middleware.custom_not_found_view')
+    def test_show_public_if_no_tenant_found_with_class_view(self):
+        response = self.client.get('/', HTTP_HOST='nonexistent.fast-test.com')
+        self.assertIsInstance(response, HttpResponseNotFound)
+        self.assertEqual(response.content, b"Custom 404 Not Found")
+
+    @override_settings(DEFAULT_NOT_FOUND_TENANT_VIEW='django_tenants.tests.test_middleware.CustomNotFoundView')
+    def test_show_public_if_no_tenant_found_with_function_view(self):
+        response = self.client.get('/', HTTP_HOST='nonexistent.fast-test.com')
+        self.assertIsInstance(response, HttpResponseNotFound)
+        self.assertEqual(response.content, b"Custom 404 Not Found")

--- a/django_tenants/tests/test_middleware.py
+++ b/django_tenants/tests/test_middleware.py
@@ -35,6 +35,7 @@ class InvalidHostname(FastTenantTestCase):
         self.assertIsInstance(response, HttpResponseNotFound)
 
 
+@override_settings(ALLOWED_HOSTS=['nonexistent.fast-test.com', 'tenant.fast-test.com'])
 class WhenTenantNotFound(FastTenantTestCase):
     @classmethod
     def get_test_tenant_domain(cls):

--- a/django_tenants/tests/test_middleware.py
+++ b/django_tenants/tests/test_middleware.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseNotFound
+from django.http import HttpResponseNotFound, JsonResponse
 from django.test.utils import override_settings
 from django.views import View
 
@@ -7,12 +7,12 @@ from django_tenants.test.client import TenantClient
 
 
 def custom_not_found_view(request):
-    return HttpResponseNotFound("Custom 404 Not Found")
+    return JsonResponse({'error': 'Custom 404 Not Found'}, status=404)
 
 
 class CustomNotFoundView(View):
     def get(self, request):
-        return HttpResponseNotFound("Custom 404 Not Found")
+        return JsonResponse({'error': 'Custom 404 Not Found'}, status=404)
 
 
 class InvalidHostname(FastTenantTestCase):
@@ -46,13 +46,15 @@ class WhenTenantNotFound(FastTenantTestCase):
         self.client = TenantClient(self.tenant)
 
     @override_settings(DEFAULT_NOT_FOUND_TENANT_VIEW='django_tenants.tests.test_middleware.custom_not_found_view')
+    @override_settings(ALLOWED_HOSTS=['nonexistent.fast-test.com', 'tenant.fast-test.com'])
     def test_custom_function_based_view_is_shown(self):
         response = self.client.get('/', HTTP_HOST='nonexistent.fast-test.com')
-        self.assertIsInstance(response, HttpResponseNotFound)
-        self.assertEqual(response.content, b"Custom 404 Not Found")
+        self.assertIsInstance(response, JsonResponse)
+        self.assertEqual(response.json(), {'error': 'Custom 404 Not Found'})
 
     @override_settings(DEFAULT_NOT_FOUND_TENANT_VIEW='django_tenants.tests.test_middleware.CustomNotFoundView')
+    @override_settings(ALLOWED_HOSTS=['nonexistent.fast-test.com', 'tenant.fast-test.com'])
     def test_custom_class_based_view_is_shown(self):
         response = self.client.get('/', HTTP_HOST='nonexistent.fast-test.com')
-        self.assertIsInstance(response, HttpResponseNotFound)
-        self.assertEqual(response.content, b"Custom 404 Not Found")
+        self.assertIsInstance(response, JsonResponse)
+        self.assertEqual(response.json(), {'error': 'Custom 404 Not Found'})

--- a/django_tenants/tests/test_middleware.py
+++ b/django_tenants/tests/test_middleware.py
@@ -35,7 +35,7 @@ class InvalidHostname(FastTenantTestCase):
         self.assertIsInstance(response, HttpResponseNotFound)
 
 
-class ShowPublicNoTenantFound(FastTenantTestCase):
+class WhenTenantNotFound(FastTenantTestCase):
     @classmethod
     def get_test_tenant_domain(cls):
         return 'tenant.fast-test.com'
@@ -45,13 +45,13 @@ class ShowPublicNoTenantFound(FastTenantTestCase):
         self.client = TenantClient(self.tenant)
 
     @override_settings(DEFAULT_NOT_FOUND_TENANT_VIEW='django_tenants.tests.test_middleware.custom_not_found_view')
-    def test_show_public_if_no_tenant_found_with_class_view(self):
+    def test_custom_function_based_view_is_shown(self):
         response = self.client.get('/', HTTP_HOST='nonexistent.fast-test.com')
         self.assertIsInstance(response, HttpResponseNotFound)
         self.assertEqual(response.content, b"Custom 404 Not Found")
 
     @override_settings(DEFAULT_NOT_FOUND_TENANT_VIEW='django_tenants.tests.test_middleware.CustomNotFoundView')
-    def test_show_public_if_no_tenant_found_with_function_view(self):
+    def test_custom_class_based_view_is_shown(self):
         response = self.client.get('/', HTTP_HOST='nonexistent.fast-test.com')
         self.assertIsInstance(response, HttpResponseNotFound)
         self.assertEqual(response.content, b"Custom 404 Not Found")

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -255,7 +255,7 @@ Other settings
 By default if no tenant is found it will raise an error Http404 however you add ```SHOW_PUBLIC_IF_NO_TENANT_FOUND``` to
 the setting it will display the the public tenant. This will not work for subfolders.
 
-```DEFAULT_NOT_FOUND_TENANT_VIEW``` If set, specifies a path to a view (function-based or class-based) that will handle requests when no tenant is found for the current domain. `DEFAULT_NOT_FOUND_TENANT_VIEW='myapp.views.my_view'`
+```DEFAULT_NOT_FOUND_TENANT_VIEW``` If set, specifies a path to a view (function-based or class-based) that will handle requests when no tenant is found for the current domain. It uses the public schema `DEFAULT_NOT_FOUND_TENANT_VIEW='myapp.views.my_view'`
 
 Admin
 ~~~~~

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -255,6 +255,7 @@ Other settings
 By default if no tenant is found it will raise an error Http404 however you add ```SHOW_PUBLIC_IF_NO_TENANT_FOUND``` to
 the setting it will display the the public tenant. This will not work for subfolders.
 
+```DEFAULT_NOT_FOUND_TENANT_VIEW``` If set, specifies a path to a view (function-based or class-based) that will handle requests when no tenant is found for the current domain.
 
 Admin
 ~~~~~

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -255,7 +255,7 @@ Other settings
 By default if no tenant is found it will raise an error Http404 however you add ```SHOW_PUBLIC_IF_NO_TENANT_FOUND``` to
 the setting it will display the the public tenant. This will not work for subfolders.
 
-```DEFAULT_NOT_FOUND_TENANT_VIEW``` If set, specifies a path to a view (function-based or class-based) that will handle requests when no tenant is found for the current domain.
+```DEFAULT_NOT_FOUND_TENANT_VIEW``` If set, specifies a path to a view (function-based or class-based) that will handle requests when no tenant is found for the current domain. `DEFAULT_NOT_FOUND_TENANT_VIEW='myapp.views.my_view'`
 
 Admin
 ~~~~~

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -28,6 +28,7 @@ pushd dts_test_project
 EXECUTORS=( standard multiprocessing )
 
 for executor in "${EXECUTORS[@]}"; do
+    echo "Running tests with executor: $executor"
     EXECUTOR=$executor PYTHONWARNINGS=d coverage run manage.py test -v2 django_tenants
 done
 


### PR DESCRIPTION
Add DEFAULT_NOT_FOUND_TENANT_VIEW setting to allow custom handling of tenant not found scenarios through a configurable view

I'm currently using this settings in a personal projects and works like a charm!