### PR TITLE
Add LRU cache to hostname extraction for improved performance

### DIFF
--- a/django_tenants/middleware/main.py
+++ b/django_tenants/middleware/main.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from django.conf import settings
 from django.core.exceptions import DisallowedHost
 from django.db import connection
@@ -19,6 +20,7 @@ class TenantMainMiddleware(MiddlewareMixin):
     """
 
     @staticmethod
+    @lru_cache(maxsize=128)
     def hostname_from_request(request):
         """ Extracts hostname from request. Used for custom requests filtering.
             By default removes the request's port and common prefixes.


### PR DESCRIPTION
Add LRU cache to hostname_from_request method

Implements LRU (Least Recently Used) caching with a maximum size of 128 entries for the hostname_from_request method. This optimization:

- Improves performance by avoiding repeated processing of the same hostnames
- Reduces request processing overhead by caching frequently accessed results 
- Maintains memory bounds by setting maxsize=128

Since hostname_from_request is called on every request to extract and normalize the hostname, the cache will particularly help in high-traffic scenarios.