### PR TITLE
Fix: cloning when TENANT_BASE_SCHEMA does not exist in the DB

### DIFF
--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -180,8 +180,9 @@ class TenantMixin(models.Model):
         fake_migrations = get_creation_fakes_migrations()
 
         if sync_schema:
-            if fake_migrations and (base_schema := schema_exists(get_tenant_base_schema())):
+            if fake_migrations and schema_exists(get_tenant_base_schema()):
                 # copy tables and data from provided model schema
+                base_schema = get_tenant_base_schema()
                 clone_schema = CloneSchema()
                 clone_schema.clone_schema(base_schema, self.schema_name)
 

--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -180,9 +180,8 @@ class TenantMixin(models.Model):
         fake_migrations = get_creation_fakes_migrations()
 
         if sync_schema:
-            if fake_migrations:
+            if fake_migrations and (base_schema := schema_exists(get_tenant_base_schema())):
                 # copy tables and data from provided model schema
-                base_schema = get_tenant_base_schema()
                 clone_schema = CloneSchema()
                 clone_schema.clone_schema(base_schema, self.schema_name)
 


### PR DESCRIPTION
clone_schema fails silently if TENANT_BASE_SCHEMA does not exist in the DB. Thus it should fallback to creating the schema.
Possible example: first time to run test cases and it is a blank database