### PR TITLE
Refactor to use class properties for settings configuration

### DIFF
--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -333,17 +333,6 @@ class BaseSyncTest(BaseTestCase):
                    'django.contrib.contenttypes', )  # 1 table
     TENANT_APPS = ('django.contrib.sessions', )
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.INSTALLED_APPS = cls.SHARED_APPS + cls.TENANT_APPS
-
-        settings.SHARED_APPS = cls.SHARED_APPS
-        settings.TENANT_APPS = cls.TENANT_APPS
-        settings.INSTALLED_APPS = cls.INSTALLED_APPS
-
-        cls.available_apps = cls.INSTALLED_APPS
-
     def setUp(self):
         super().setUp()
         # Django calls syncdb by default for the test database, but we want

--- a/django_tenants/tests/testcases.py
+++ b/django_tenants/tests/testcases.py
@@ -11,15 +11,19 @@ class BaseTestCase(TransactionTestCase):
     Base test case that comes packed with overloaded INSTALLED_APPS,
     custom public tenant, and schemas cleanup on tearDown.
     """
+
+    TENANT_APPS = ('dts_test_app',
+                   'django.contrib.contenttypes',
+                   'django.contrib.auth', )
+    SHARED_APPS = ('django_tenants',
+                   'customers')
+
     @classmethod
     def setUpClass(cls):
         settings.TENANT_MODEL = 'customers.Client'
         settings.TENANT_DOMAIN_MODEL = 'customers.Domain'
-        settings.SHARED_APPS = ('django_tenants',
-                                'customers')
-        settings.TENANT_APPS = ('dts_test_app',
-                                'django.contrib.contenttypes',
-                                'django.contrib.auth', )
+        settings.SHARED_APPS = cls.SHARED_APPS
+        settings.TENANT_APPS = cls.TENANT_APPS
         settings.INSTALLED_APPS = settings.SHARED_APPS + settings.TENANT_APPS
         if '.test.com' not in settings.ALLOWED_HOSTS:
             settings.ALLOWED_HOSTS += ['.test.com']


### PR DESCRIPTION
This pull request refactors the test setup by centralizing the configuration of the SHARED_APPS and TENANT_APPS properties. This change is necessary for upgrading to Django 5.2 https://github.com/django-tenants/django-tenants/pull/1138

In Django 5.2, _pre_setup() is now invoked within setupClass(). As a result, calling super().setUpClass() already triggers _pre_setup(), initializing Django with the apps hardcoded in BaseTestCase.setUpClass().

Therefore, setting the SHARED_APPS and TENANT_APPS properties after the super() call has no effect.

Additionally, I could not find a reference to cls.INSTALLED_APPS, so I have removed it.