### PR TITLE
Formally support python 3.13

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         django-version: ["==4.2.*", "==5.0.*", "==5.1.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,10 @@ setup(
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
         'Programming Language :: Python',
-         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
         'Programming Language :: Python',
+         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
Added Python 3.13 to GitHub Actions and updated the classifiers accordingly. Removed unsupported Python versions 3.8 and 3.9, as they are no longer tested.