### PR TITLE
Django52

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -14,7 +14,7 @@ jobs:
       matrix: # https://www.postgresql.org/docs/release
         # always use latest Python b/c the point here is to test PostgreSQL compatibility
         python-version: ["3.12"]
-        postgres-version: [13, 14, 15, 16, 17]
+        postgres-version: [14, 15, 16, 17]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        django-version: ["==4.2.*", "==5.0.*", "==5.1.*"]
+        django-version: ["==4.2.*", "==5.0.*", "==5.1.*", "==5.2.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
     steps:

--- a/django_tenants/management/commands/migrate_schemas.py
+++ b/django_tenants/management/commands/migrate_schemas.py
@@ -1,3 +1,5 @@
+from django.db.migrations.autodetector import MigrationAutodetector
+
 from django_tenants.migration_executors import get_executor
 from django_tenants.utils import get_tenant_model, get_public_schema_name, schema_exists, get_tenant_database_alias, \
     has_multi_type_tenants, get_multi_type_database_field_name, get_tenant_migration_order
@@ -14,6 +16,7 @@ else:
 
 
 class MigrateSchemasCommand(SyncCommon):
+    autodetector = MigrationAutodetector
     help = "Updates database schema. Manages both apps with migrations and those without."
 
     def add_arguments(self, parser):

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.db import connection, transaction
 from django.test.utils import override_settings
+from django.utils.version import get_main_version, get_version_tuple
 
 from django_tenants.clone import CloneSchema
 from django_tenants.signals import schema_migrated, schema_migrate_message, schema_pre_migration
@@ -383,9 +384,15 @@ class TestSyncTenantsWithAuth(BaseSyncTest):
                    'django.contrib.sessions', )  # 1 table
     TENANT_APPS = ('django.contrib.sessions', )  # 1 table
 
-    def _pre_setup(self):
-        self.sync_shared()
-        super()._pre_setup()
+    if get_version_tuple(get_main_version()) < (5, 2):
+        def _pre_setup(self):
+            self.sync_shared()
+            super()._pre_setup()
+    else:
+        @classmethod
+        def _pre_setup(cls):
+            cls.sync_shared()
+            super()._pre_setup()
 
     def test_tenant_apps_and_shared_apps_can_have_the_same_apps(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
         'Framework :: Django :: 5.1',
+        'Framework :: Django :: 5.2',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -54,7 +55,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     install_requires=[
-        'Django >=2.1,<5.2',
+        'Django >=2.1,<6.0',
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Based on https://github.com/django-tenants/django-tenants/pull/1138 this PR adds compatibility with Django 5.2

Postgres 13 isn't longer supported and it requires a version check for fixing the `_pre_setup` change.