### PR TITLE
Add configurable urlconf override for subfolder middleware see #1067

### DIFF
--- a/django_tenants/middleware/subfolder.py
+++ b/django_tenants/middleware/subfolder.py
@@ -20,6 +20,7 @@ class TenantSubfolderMiddleware(TenantMainMiddleware):
     """
 
     TENANT_NOT_FOUND_EXCEPTION = Http404
+    get_subfolder_urlconf_override = None
 
     def __init__(self, get_response):
         super().__init__(get_response)
@@ -64,7 +65,10 @@ class TenantSubfolderMiddleware(TenantMainMiddleware):
                 return self.no_tenant_found(request, tenant_subfolder)
 
             tenant.domain_subfolder = tenant_subfolder
-            urlconf = get_subfolder_urlconf(tenant)
+            if self.__class__.get_subfolder_urlconf_override:
+                urlconf = self.__class__.get_subfolder_urlconf_override(tenant)
+            else:
+                urlconf = get_subfolder_urlconf(tenant)
 
         tenant.domain_url = hostname
         request.tenant = tenant


### PR DESCRIPTION
Add ability to override subfolder tenant urlconf resolution. This enables temporary solution for devs to have a lighter weight way to apply the fix in #1067 / #822

Added a class-level `get_subfolder_urlconf_override` attribute to TenantSubfolderMiddleware that allows subclasses to customize how urlconfs are resolved for tenants in subfolder paths. When set, this override takes precedence over the default get_subfolder_urlconf function that seems to be where some issues are originating.

Example:
```python
class CustomTenantSubfolderMiddleware(TenantSubfolderMiddleware):
    @staticmethod
    def get_subfolder_urlconf(tenant):
    if has_multi_type_tenants():
        urlconf = get_tenant_types()[tenant.get_tenant_type()]["URLCONF"]
    else:
        urlconf = settings.ROOT_URLCONF

    subfolder_prefix = get_subfolder_prefix()

    class TenantUrlConf(ModuleType):
        urlpatterns = [
            path(
                f"{subfolder_prefix}/{tenant.domain_subfolder}/",
                include(urlconf),
            )
        ]

    return TenantUrlConf(tenant.domain_subfolder)
    
    get_subfolder_urlconf_override = get_subfolder_urlconf
  ```