### PR TITLE
Add support for SET LOCAL search_path via settings

### DIFF
--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -168,7 +168,12 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
             # we do not have to worry that it's not the good one
             try:
                 formatted_search_paths = ['\'{}\''.format(s) for s in search_paths]
-                cursor_for_search_path.execute('SET search_path = {0}'.format(','.join(formatted_search_paths)))
+                set_search_path_sql = (
+                    "SET LOCAL search_path = {0}"
+                    if getattr(settings, "TENANT_USE_SET_LOCAL", False)
+                    else "SET search_path = {0}"
+                )
+                cursor_for_search_path.execute(set_search_path_sql.format(','.join(formatted_search_paths)))
             except (django.db.utils.DatabaseError, psycopg.InternalError):
                 self.search_path_set_schemas = None
             else:


### PR DESCRIPTION
**TENANT_USE_SET_LOCAL** (optional)
Type: bool
Default: False

If set to True, uses SET LOCAL search_path instead of SET search_path when setting the PostgreSQL schema for tenants.

This is primarily needed when using database connection poolers like PgBouncer in transaction pooling mode, where SET search_path is ineffective across transactions.

SET LOCAL ensures the schema change only applies within the current transaction, making it compatible with such environments.

Example:
TENANT_USE_SET_LOCAL = True

If not defined, the system defaults to False, using the standard SET search_path.