### PR TITLE
Refactor URLconf retrieval in subfolder middleware for #1067 #1159

### DIFF
--- a/django_tenants/middleware/subfolder.py
+++ b/django_tenants/middleware/subfolder.py
@@ -64,7 +64,7 @@ class TenantSubfolderMiddleware(TenantMainMiddleware):
                 return self.no_tenant_found(request, tenant_subfolder)
 
             tenant.domain_subfolder = tenant_subfolder
-            urlconf = get_subfolder_urlconf(tenant)
+            urlconf = self.get_urlconf(tenant=tenant)
 
         tenant.domain_url = hostname
         request.tenant = tenant
@@ -75,6 +75,10 @@ class TenantSubfolderMiddleware(TenantMainMiddleware):
         if urlconf:
             request.urlconf = urlconf
             set_urlconf(urlconf)
+
+    @staticmethod
+    def get_urlconf(tenant):
+        return get_subfolder_urlconf(tenant)
 
     def no_tenant_found(self, request, hostname):
         """ What should happen if no tenant is found.


### PR DESCRIPTION
Replaces direct call to get_subfolder_urlconf with a static method get_urlconf for improved extensibility and clarity in TenantSubfolderMiddleware.