### PR TITLE
Update Django and Python support

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix: # https://www.postgresql.org/docs/release
         # always use latest Python b/c the point here is to test PostgreSQL compatibility
-        python-version: ["3.12"]
+        python-version: ["3.13"]
         postgres-version: [14, 15, 16, 17]
 
     steps:
@@ -50,9 +50,17 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        django-version: ["==4.2.*", "==5.0.*", "==5.1.*", "==5.2.*"]
+        django-version: ["==4.2.*", "==5.2.*", "==6.0.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
+        exclude:
+          - django-version: "==4.2.*"
+            python-version: "3.13"
+          - django-version: "==6.0.*"
+            python-version: "3.10"
+          - django-version: "==6.0.*"
+            python-version: "3.11"
+
     steps:
     - uses: actions/checkout@v5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.13
 #ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 VOLUME /code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,10 @@ classifiers = [
   "Environment :: Web Environment",
   "Framework :: Django",
   "Framework :: Django :: 4.2",
-  "Framework :: Django :: 5.0",
-  "Framework :: Django :: 5.1",
   "Framework :: Django :: 5.2",
+  "Framework :: Django :: 6.0",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -32,7 +29,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "django>=2.1,<6",
+  "django>=2.1,<6.1",
 ]
 
 optional-dependencies.dev = [


### PR DESCRIPTION
Add newly released Django 6.0 and remove end of life versions 5.0 and
5.1. Also remove end of life Python 3.8 and 3.9
Update django compatability testing matrix to test supported version
combinations

Closes #1197