### PR TITLE
Support Transaction Pool

### DIFF
--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -6,7 +6,13 @@ from importlib import import_module
 from django.utils.module_loading import import_string
 
 from django_tenants.postgresql_backend.introspection import DatabaseSchemaIntrospection
-from django_tenants.utils import get_public_schema_name, get_limit_set_calls
+from django_tenants.signals import tenant_transaction_began
+from django_tenants.utils import (
+    get_limit_set_calls,
+    get_public_schema_name,
+    get_pgbouncer_transaction_pooling,
+    is_transaction_pooling_disabled,
+)
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 import django.db.utils
@@ -69,6 +75,10 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         self.search_path_set_schemas = None
         self.tenant = None
         self.schema_name = None
+        # PgBouncer transaction pooling: track if search_path was set in current transaction
+        # (Option B); cleared on _commit/_rollback.
+        self._search_path_set_in_txn = False
+        self._pgbouncer_wrapper_installed = False
         super().__init__(*args, **kwargs)
 
         # Use a patched version of the DatabaseIntrospection that only returns the table list for the
@@ -79,6 +89,9 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
 
     def close(self):
         self.search_path_set_schemas = None
+        self._search_path_set_in_txn = False
+        # Do not reset _pgbouncer_wrapper_installed so we don't append the wrapper
+        # again when the connection is reopened (execute_wrappers list is reused).
         super().close()
 
     def set_tenant(self, tenant, include_public=True):
@@ -95,6 +108,8 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
             EXTRA_SET_TENANT_METHOD(self, tenant)
 
         self.search_path_set_schemas = None
+        if get_pgbouncer_transaction_pooling():
+            self._search_path_set_in_txn = False
 
         # Content type can no longer be cached as public and tenant schemas
         # have different models. If someone wants to change this, the cache
@@ -132,6 +147,31 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
                       category=DeprecationWarning)
         return self.tenant
 
+    def _set_search_path_local(self, cursor=None):
+        """
+        Run SET LOCAL search_path for the current transaction (PgBouncer
+        transaction pooling). Uses Option B: only run when _search_path_set_in_txn
+        is False; set the flag after running; caller must clear flag on
+        _commit/_rollback.
+        """
+        if not self.schema_name:
+            raise ImproperlyConfigured("Database schema not set. Did you forget "
+                                       "to call set_schema() or set_tenant()?")
+        search_paths = self._get_cursor_search_paths()
+        formatted = ['\'{}\''.format(s) for s in search_paths]
+        sql = 'SET LOCAL search_path = {0}'.format(','.join(formatted))
+        if cursor is None:
+            cursor = self.connection.cursor()
+        try:
+            cursor.execute(sql)
+        except (django.db.utils.DatabaseError, psycopg.InternalError):
+            self._search_path_set_in_txn = False
+            raise
+        self._search_path_set_in_txn = True
+        tenant_transaction_began.send(
+            sender=None, connection=self, schema_name=self.schema_name
+        )
+
     def _cursor(self, name=None):
         """
         Here it happens. We hope every Django db operation using PostgreSQL
@@ -143,38 +183,51 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         else:
             cursor = super()._cursor()
 
-        # optionally limit the number of executions - under load, the execution
-        # of `set search_path` can be quite time consuming
-        if (not get_limit_set_calls()) or not self.search_path_set_schemas:
-            # Actual search_path modification for the cursor. Database will
-            # search schemata from left to right when looking for the object
-            # (table, index, sequence, etc.).
-            if not self.schema_name:
-                raise ImproperlyConfigured("Database schema not set. Did you forget "
-                                           "to call set_schema() or set_tenant()?")
+        use_pooling = (
+            get_pgbouncer_transaction_pooling()
+            and not is_transaction_pooling_disabled()
+        )
 
-            search_paths = self._get_cursor_search_paths()
+        if use_pooling:
+            # PgBouncer transaction pooling: use SET LOCAL and set once per
+            # transaction (Option B).
+            if not self._search_path_set_in_txn:
+                if not self.schema_name:
+                    raise ImproperlyConfigured("Database schema not set. Did you forget "
+                                               "to call set_schema() or set_tenant()?")
+                if name or is_psycopg3:
+                    cursor_for_search_path = self.connection.cursor()
+                else:
+                    cursor_for_search_path = cursor
+                try:
+                    self._set_search_path_local(cursor_for_search_path)
+                except (django.db.utils.DatabaseError, psycopg.InternalError):
+                    pass  # already cleared in _set_search_path_local
+                if name or is_psycopg3:
+                    cursor_for_search_path.close()
+        else:
+            # Original behavior: session-level SET search_path, optionally limited
+            if (not get_limit_set_calls()) or not self.search_path_set_schemas:
+                if not self.schema_name:
+                    raise ImproperlyConfigured("Database schema not set. Did you forget "
+                                               "to call set_schema() or set_tenant()?")
 
-            if name or is_psycopg3:
-                # Named cursor can only be used once, psycopg3 and Django 4 have recursion issue
-                cursor_for_search_path = self.connection.cursor()
-            else:
-                # Reuse
-                cursor_for_search_path = cursor
+                search_paths = self._get_cursor_search_paths()
 
-            # In the event that an error already happened in this transaction and we are going
-            # to rollback we should just ignore database error when setting the search_path
-            # if the next instruction is not a rollback it will just fail also, so
-            # we do not have to worry that it's not the good one
-            try:
-                formatted_search_paths = ['\'{}\''.format(s) for s in search_paths]
-                cursor_for_search_path.execute('SET search_path = {0}'.format(','.join(formatted_search_paths)))
-            except (django.db.utils.DatabaseError, psycopg.InternalError):
-                self.search_path_set_schemas = None
-            else:
-                self.search_path_set_schemas = search_paths
-            if name or is_psycopg3:
-                cursor_for_search_path.close()
+                if name or is_psycopg3:
+                    cursor_for_search_path = self.connection.cursor()
+                else:
+                    cursor_for_search_path = cursor
+
+                try:
+                    formatted_search_paths = ['\'{}\''.format(s) for s in search_paths]
+                    cursor_for_search_path.execute('SET search_path = {0}'.format(','.join(formatted_search_paths)))
+                except (django.db.utils.DatabaseError, psycopg.InternalError):
+                    self.search_path_set_schemas = None
+                else:
+                    self.search_path_set_schemas = search_paths
+                if name or is_psycopg3:
+                    cursor_for_search_path.close()
         return cursor
 
     def _get_cursor_search_paths(self):
@@ -191,6 +244,48 @@ class DatabaseWrapper(original_backend.DatabaseWrapper):
         search_paths.extend(EXTRA_SEARCH_PATHS)
 
         return search_paths
+
+    def _commit(self):
+        if get_pgbouncer_transaction_pooling():
+            self._search_path_set_in_txn = False
+        super()._commit()
+
+    def _rollback(self):
+        if get_pgbouncer_transaction_pooling():
+            self._search_path_set_in_txn = False
+        super()._rollback()
+
+    def ensure_connection(self):
+        super().ensure_connection()
+        if (
+            get_pgbouncer_transaction_pooling()
+            and not is_transaction_pooling_disabled()
+            and not getattr(self, '_pgbouncer_wrapper_installed', False)
+        ):
+            self.execute_wrappers.append(self._make_pgbouncer_execute_wrapper())
+            self._pgbouncer_wrapper_installed = True
+
+    def _make_pgbouncer_execute_wrapper(self):
+        """Return an execute wrapper that wraps autocommit-mode runs in BEGIN/COMMIT."""
+        connection = self
+
+        def pgbouncer_execute_wrapper(execute, sql, params, many, context):
+            if is_transaction_pooling_disabled():
+                return execute(sql, params, many, context)
+            if connection.get_autocommit() and not connection.in_atomic_block:
+                connection.set_autocommit(False)
+                try:
+                    # Open/close a cursor so _cursor() runs and sets SET LOCAL for this txn
+                    if connection.schema_name:
+                        with connection.cursor():
+                            pass
+                    result = execute(sql, params, many, context)
+                finally:
+                    connection.set_autocommit(True)
+                return result
+            return execute(sql, params, many, context)
+
+        return pgbouncer_execute_wrapper
 
 
 class FakeTenant:

--- a/django_tenants/signals.py
+++ b/django_tenants/signals.py
@@ -43,6 +43,16 @@ Argument Required = message
 """
 
 
+tenant_transaction_began = Signal()
+tenant_transaction_began.__doc__ = """
+Sent after a transaction has begun and SET LOCAL search_path has been set
+(PgBouncer transaction pooling mode). Use for custom SQL that must run at
+transaction start.
+
+Arguments: connection, schema_name
+"""
+
+
 @receiver(post_delete)
 def tenant_delete_callback(sender, instance, **kwargs):
     if not isinstance(instance, get_tenant_model()):

--- a/django_tenants/tests/test_pgbouncer.py
+++ b/django_tenants/tests/test_pgbouncer.py
@@ -1,0 +1,159 @@
+"""
+Tests for PgBouncer transaction pooling support (TENANT_PGBOUNCER_TRANSACTION_POOLING).
+"""
+from unittest import mock
+
+from django.db import connection, transaction
+from django.test import override_settings
+
+from django_tenants.signals import tenant_transaction_began
+from django_tenants.tests.testcases import BaseTestCase
+from django_tenants.utils import (
+    disable_transaction_pooling,
+    get_public_schema_name,
+    get_tenant_domain_model,
+    get_tenant_model,
+)
+from dts_test_app.models import DummyModel
+
+
+class PgBouncerTransactionPoolingTest(BaseTestCase):
+    """Test PgBouncer transaction pooling behavior."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from django.conf import settings
+        settings.SHARED_APPS = ('django_tenants', 'customers')
+        settings.TENANT_APPS = (
+            'dts_test_app',
+            'django.contrib.contenttypes',
+            'django.contrib.auth',
+        )
+        settings.INSTALLED_APPS = settings.SHARED_APPS + settings.TENANT_APPS
+        cls.sync_shared()
+
+        cls.public_tenant = get_tenant_model()(schema_name=get_public_schema_name())
+        cls.public_tenant.save()
+        cls.public_domain = get_tenant_domain_model()(
+            tenant=cls.public_tenant, domain='test.com'
+        )
+        cls.public_domain.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.public_domain.delete()
+        cls.public_tenant.delete()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        connection.set_schema_to_public()
+        self.created = []
+
+    def tearDown(self):
+        from django_tenants.models import TenantMixin
+        connection.set_schema_to_public()
+        for c in self.created:
+            if isinstance(c, TenantMixin):
+                c.delete(force_drop=True)
+            else:
+                c.delete()
+        super().tearDown()
+
+    def test_pooling_off_default_behavior(self):
+        """With pooling off (default), normal session-level search_path behavior."""
+        tenant = get_tenant_model()(schema_name='pooltest1')
+        tenant.save()
+        domain = get_tenant_domain_model()(tenant=tenant, domain='pooltest1.test.com')
+        domain.save()
+        self.created = [domain, tenant]
+
+        connection.set_tenant(tenant)
+        DummyModel(name='one').save()
+        self.assertEqual(DummyModel.objects.count(), 1)
+        connection.set_schema_to_public()
+
+    @override_settings(TENANT_PGBOUNCER_TRANSACTION_POOLING=True)
+    def test_pooling_on_autocommit_queries_succeed(self):
+        """With pooling on, autocommit-mode queries run in explicit transactions."""
+        tenant = get_tenant_model()(schema_name='pooltest2')
+        tenant.save()
+        domain = get_tenant_domain_model()(tenant=tenant, domain='pooltest2.test.com')
+        domain.save()
+        self.created = [domain, tenant]
+
+        connection.set_tenant(tenant)
+        DummyModel(name='one').save()
+        DummyModel(name='two').save()
+        self.assertEqual(DummyModel.objects.count(), 2)
+        connection.set_schema_to_public()
+
+    @override_settings(TENANT_PGBOUNCER_TRANSACTION_POOLING=True)
+    def test_pooling_on_atomic_single_transaction(self):
+        """With pooling on, transaction.atomic() uses one txn, SET LOCAL once."""
+        tenant = get_tenant_model()(schema_name='pooltest3')
+        tenant.save()
+        domain = get_tenant_domain_model()(tenant=tenant, domain='pooltest3.test.com')
+        domain.save()
+        self.created = [domain, tenant]
+
+        connection.set_tenant(tenant)
+        with transaction.atomic():
+            DummyModel(name='a').save()
+            DummyModel(name='b').save()
+            self.assertEqual(DummyModel.objects.count(), 2)
+        self.assertEqual(DummyModel.objects.count(), 2)
+        connection.set_schema_to_public()
+
+    @override_settings(TENANT_PGBOUNCER_TRANSACTION_POOLING=True)
+    def test_pooling_on_opt_out(self):
+        """With pooling on, disable_transaction_pooling() skips wrapping."""
+        tenant = get_tenant_model()(schema_name='pooltest4')
+        tenant.save()
+        domain = get_tenant_domain_model()(tenant=tenant, domain='pooltest4.test.com')
+        domain.save()
+        self.created = [domain, tenant]
+
+        connection.set_tenant(tenant)
+        with disable_transaction_pooling():
+            DummyModel(name='x').save()
+        self.assertEqual(DummyModel.objects.count(), 1)
+        connection.set_schema_to_public()
+
+    @override_settings(TENANT_PGBOUNCER_TRANSACTION_POOLING=True)
+    def test_pooling_on_search_path_cleared_after_commit(self):
+        """With pooling on, _search_path_set_in_txn is cleared after commit."""
+        tenant = get_tenant_model()(schema_name='pooltest5')
+        tenant.save()
+        domain = get_tenant_domain_model()(tenant=tenant, domain='pooltest5.test.com')
+        domain.save()
+        self.created = [domain, tenant]
+
+        connection.set_tenant(tenant)
+        with transaction.atomic():
+            DummyModel(name='y').save()
+            self.assertTrue(connection._search_path_set_in_txn)
+        self.assertFalse(connection._search_path_set_in_txn)
+        connection.set_schema_to_public()
+
+    @override_settings(TENANT_PGBOUNCER_TRANSACTION_POOLING=True)
+    def test_tenant_transaction_began_signal_sent(self):
+        """With pooling on, tenant_transaction_began is sent when SET LOCAL runs."""
+        tenant = get_tenant_model()(schema_name='pooltest6')
+        tenant.save()
+        domain = get_tenant_domain_model()(tenant=tenant, domain='pooltest6.test.com')
+        domain.save()
+        self.created = [domain, tenant]
+
+        connection.set_tenant(tenant)
+        handler = mock.Mock()
+        tenant_transaction_began.connect(handler)
+        self.addCleanup(tenant_transaction_began.disconnect, handler)
+
+        DummyModel(name='z').save()
+        self.assertGreaterEqual(handler.call_count, 1)
+        call_kwargs = handler.call_args[1]
+        self.assertEqual(call_kwargs.get('schema_name'), 'pooltest6')
+        self.assertIs(call_kwargs.get('connection'), connection)
+        connection.set_schema_to_public()

--- a/django_tenants/utils.py
+++ b/django_tenants/utils.py
@@ -1,5 +1,6 @@
 import os
-from contextlib import ContextDecorator
+from contextlib import ContextDecorator, contextmanager
+from contextvars import ContextVar
 from functools import lru_cache, wraps
 from types import ModuleType
 
@@ -73,6 +74,46 @@ def get_tenant_type_choices():
 
 def get_limit_set_calls():
     return getattr(settings, 'TENANT_LIMIT_SET_CALLS', False)
+
+
+def get_pgbouncer_transaction_pooling():
+    """
+    When True, enable PgBouncer transaction pooling support: every unit of work
+    runs in an explicit transaction and search_path is set with SET LOCAL
+    so it does not leak to other clients. Only enable when using PgBouncer
+    (or similar) in transaction pooling mode.
+    """
+    return getattr(settings, 'TENANT_PGBOUNCER_TRANSACTION_POOLING', False)
+
+
+# Context var to opt out of transaction pooling behavior (e.g. raw SQL managing
+# its own transaction, or migrations that need different behavior).
+_tenant_disable_transaction_pooling: ContextVar[bool] = ContextVar(
+    'tenant_disable_transaction_pooling', default=False
+)
+
+
+def is_transaction_pooling_disabled():
+    """Return True if the current context has disabled transaction pooling."""
+    return _tenant_disable_transaction_pooling.get()
+
+
+@contextmanager
+def disable_transaction_pooling():
+    """
+    Context manager to disable PgBouncer transaction pooling behavior for a
+    block. Use when code manages its own transactions (e.g. raw SQL with
+    BEGIN/COMMIT) or when migrations need different behavior.
+
+    Example:
+        with disable_transaction_pooling():
+            cursor.execute("BEGIN; ... COMMIT;")
+    """
+    token = _tenant_disable_transaction_pooling.set(True)
+    try:
+        yield
+    finally:
+        _tenant_disable_transaction_pooling.reset(token)
 
 
 def get_subfolder_prefix():

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -528,6 +528,42 @@ The hook for ensuring the ``search_path`` is set properly happens inside the ``D
 When set, ``django-tenants`` will set the search path only once per request. The default is ``False``.
 
 
+PgBouncer transaction pooling
+-----------------------------
+
+When using PostgreSQL behind PgBouncer (or a similar connection pooler) in **transaction** pooling mode, the server connection is returned to the pool after each transaction. Session-level ``SET search_path`` would then affect the next client using that connection. To support this setup, django-tenants can run every unit of work in an explicit transaction and set the tenant schema with ``SET LOCAL search_path`` so the setting is transaction-scoped and does not leak.
+
+**When to use:** Only when your app connects to PostgreSQL through PgBouncer in **transaction** pooling mode. Do not enable for session pooling or when not using a pooler.
+
+**How to enable:** Set in ``settings.py``:
+
+.. code-block:: python
+
+    TENANT_PGBOUNCER_TRANSACTION_POOLING = True
+
+When enabled:
+
+- Every database operation runs in an explicit transaction (autocommit-mode statements are wrapped in BEGIN/COMMIT).
+- The tenant schema is set with ``SET LOCAL search_path`` at the start of each transaction, and only once per transaction (tracked and cleared on commit/rollback).
+
+**Opt-out:** For code that must not be wrapped (e.g. raw SQL that manages its own transaction, or migrations that need different behavior), use the context manager from ``django_tenants.utils``:
+
+.. code-block:: python
+
+    from django_tenants.utils import disable_transaction_pooling
+
+    with disable_transaction_pooling():
+        cursor.execute("BEGIN; ... COMMIT;")
+
+**Caveats:**
+
+- With pooling enabled, ``run_on_commit`` callbacks run after each single-statement "synthetic" transaction when in autocommit mode. For "only after my explicit atomic" semantics, use an explicit ``transaction.atomic()``.
+- Server-side (named) cursors and nested ``transaction.atomic()`` are handled: the wrapper does not commit in the middle.
+- Migrations and schema clone can use ``disable_transaction_pooling()`` if needed.
+
+**Signal:** When pooling is on, ``tenant_transaction_began`` is sent after ``SET LOCAL search_path`` is run at transaction start (arguments: ``connection``, ``schema_name``). Use it for custom SQL that must run at transaction start.
+
+
 Extra Set Tenant Method
 -----------------------
 


### PR DESCRIPTION
Summary

This PR adds optional, first-class support for running django-tenants behind PgBouncer (or similar poolers) in transaction pooling mode, without leaking search_path between clients.

What’s included

- New setting: TENANT_PGBOUNCER_TRANSACTION_POOLING
  When True, django-tenants runs all work inside explicit transactions and sets the tenant schema with SET LOCAL search_path, so the schema is scoped to the current transaction only.
  The default is False, so existing behavior (session-level SET search_path) is unchanged.

- Backend changes (PostgreSQL backend wrapper)
  DatabaseWrapper now tracks whether search_path has been set in the current transaction and only runs SET LOCAL once per transaction.
  Autocommit-mode statements are transparently wrapped in BEGIN/COMMIT when pooling is enabled, so they still see the correct tenant schema.
  The tracking flag is cleared on _commit/_rollback to avoid leaking state across transactions.

- New utilities in django_tenants.utils
  get_pgbouncer_transaction_pooling() reads the new setting and drives the backend behavior.
  disable_transaction_pooling() context manager plus is_transaction_pooling_disabled() helper let callers opt out of the wrapping behavior for specific code paths (for example, raw SQL that manages its own transactions, or migrations that need different handling).

- New signal: tenant_transaction_began
  Emitted after SET LOCAL search_path runs at transaction start when pooling is enabled.
  Provides connection and schema_name so applications can hook in custom SQL that must run at the beginning of each transaction.

- Documentation updates (docs/use.rst)
  Adds a “PgBouncer transaction pooling” section explaining:
    - When to use this mode (only for transaction pooling, not session pooling).
    - How to enable TENANT_PGBOUNCER_TRANSACTION_POOLING and what changes in behavior.
    - The opt-out pattern using disable_transaction_pooling().
    - Important caveats, such as how run_on_commit behaves under synthetic transactions.

- Tests
  New PgBouncerTransactionPoolingTest coverage to verify:
    - Default (pooling off) behavior remains unchanged.
    - Autocommit queries succeed and run inside explicit transactions when pooling is on.
    - transaction.atomic() uses a single transaction and runs SET LOCAL once.
    - disable_transaction_pooling() correctly skips the wrapping behavior.
    - The internal _search_path_set_in_txn flag is cleared on commit.
    - tenant_transaction_began is emitted with the expected arguments.

Backward compatibility / risk

TENANT_PGBOUNCER_TRANSACTION_POOLING is off by default; existing deployments keep their current behavior.
When enabled, the behavior is opt-in, documented, and guarded by tests; callers can selectively opt out per code path via disable_transaction_pooling().