### PR TITLE
Fix installing stray files into site-packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+graft docs
+graft examples
+graft dts_test_project
+
+global-exclude *.py[cod] __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ optional-dependencies.dev = [
 urls."Homepage" = "https://github.com/django-tenants/django-tenants"
 
 [tool.setuptools]
-include-package-data = true
+include-package-data = false
 zip-safe = false
 
 [tool.setuptools.packages.find]
@@ -58,16 +58,10 @@ include = [
   "django_tenants.tests",
   "django_tenants.staticfiles",
   "django_tenants.middleware",
-  "docs",
-  "examples",
-  "dts_test_project",
 ]
 
 [tool.setuptools.package-data]
 "django_tenants" = [ "templates/**/*.html" ]
-"docs" = [ "**/*" ]
-"examples" = [ "**/*" ]
-"dts_test_project" = [ "**/*" ]
 
 [tool.setuptools.exclude-package-data]
 "*" = [ "*.pyc", "*.pyo" ]


### PR DESCRIPTION
Fix the package configuration not to install stray top-level directories such as `docs`, `examples`, and `dts_test_project` into site-packages.

These files remain in the sdist, but are no longer included in wheels.

Related:
- https://github.com/NixOS/nixpkgs/issues/516785
- https://github.com/pyca/cryptography/pull/14319
