### PR TITLE
Add a subprocess migration executor

### DIFF
--- a/django_tenants/management/commands/migrate_schemas.py
+++ b/django_tenants/management/commands/migrate_schemas.py
@@ -52,6 +52,10 @@ class MigrateSchemasCommand(SyncCommon):
                             help='Creates tables for apps without migrations.')
         parser.add_argument('--check', action='store_true', dest='check_unapplied',
                             help='Exits with a non-zero status if unapplied migrations exist.')
+        parser.add_argument('--parallel', type=int, default=None,
+                            help='Number of tenant migrations to run in parallel. Only used '
+                                 'by --executor=subprocess. Overrides TENANT_SUBPROCESS_PARALLEL '
+                                 '(default: 1).')
 
     def handle(self, *args, **options):
         super().handle(*args, **options)

--- a/django_tenants/migration_executors/__init__.py
+++ b/django_tenants/migration_executors/__init__.py
@@ -3,6 +3,7 @@ import os
 from .base import MigrationExecutor
 from .multiproc import MultiprocessingExecutor  # noqa
 from .standard import StandardExecutor
+from .subproc import SubprocessExecutor  # noqa
 
 
 def get_executor(codename=None):

--- a/django_tenants/migration_executors/subproc.py
+++ b/django_tenants/migration_executors/subproc.py
@@ -1,0 +1,139 @@
+"""Subprocess-based migration executor.
+
+Spawns a fresh ``python manage.py migrate_schemas --schema <name>`` process
+for each tenant. Optionally runs N processes in parallel via a thread pool.
+
+See migration_executors/__init__.py for executor selection and
+docs/use.rst for configuration.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from django.conf import settings
+from django.db import connections
+
+from .base import MigrationExecutor, run_migrations
+
+
+def _options_to_argv(options: dict) -> list[str]:
+    """Translate parsed migrate_schemas options into CLI args for the child.
+
+    Only flags that affect migration behavior are forwarded. The child always
+    runs with ``--executor=standard`` to avoid recursive fan-out.
+    """
+    argv: list[str] = []
+    if not options.get("interactive", True):
+        argv.append("--noinput")
+    if options.get("skip_checks"):
+        argv.append("--skip-checks")
+    if options.get("fake"):
+        argv.append("--fake")
+    if options.get("fake_initial"):
+        argv.append("--fake-initial")
+    if options.get("prune"):
+        argv.append("--prune")
+    if options.get("run_syncdb"):
+        argv.append("--run-syncdb")
+    if options.get("check_unapplied"):
+        argv.append("--check")
+    if options.get("plan"):
+        argv.append("--plan")
+    if options.get("list"):
+        argv.append("--list")
+    if not options.get("load_initial_data", True):
+        argv.append("--no-initial-data")
+    if options.get("database"):
+        argv += ["--database", options["database"]]
+    verbosity = options.get("verbosity", 1)
+    if verbosity != 1:
+        argv += ["--verbosity", str(verbosity)]
+    return argv
+
+
+def _manage_py() -> str:
+    if sys.argv and sys.argv[0].endswith("manage.py"):
+        return str(Path(sys.argv[0]).resolve())
+    return str(Path("manage.py").resolve())
+
+
+class SubprocessExecutor(MigrationExecutor):
+    """Run each tenant migration in a fresh OS process."""
+
+    codename = "subprocess"
+
+    def _max_parallel(self) -> int:
+        explicit = self.options.get("parallel")
+        if explicit is not None:
+            return max(1, int(explicit))
+        return max(1, int(getattr(settings, "TENANT_SUBPROCESS_PARALLEL", 1)))
+
+    def _close_connections(self) -> None:
+        connection = connections[self.TENANT_DB_ALIAS]
+        connection.close()
+        connection.connection = None
+
+    def _run_in_subprocess(self, schema_name: str) -> None:
+        cmd: list[str] = [
+            sys.executable,
+            _manage_py(),
+            "migrate_schemas",
+            "--executor=standard",
+            "--schema",
+            schema_name,
+        ]
+        cmd += list(self.args)
+        cmd += _options_to_argv(self.options)
+        completed = subprocess.run(cmd)
+        if completed.returncode != 0:
+            # Match StandardExecutor: propagate the child's rc and stop the
+            # tenant loop. Covers both real migrate failures and --check
+            # signaling pending migrations.
+            raise SystemExit(completed.returncode)
+
+    def _run_parallel(self, tenants: list[str], parallel: int) -> None:
+        # In-flight subprocesses cannot be safely killed mid-DDL. On first
+        # failure we cancel not-yet-started tasks and let the pool's
+        # __exit__ wait for in-flight to drain before the SystemExit
+        # propagates.
+        with ThreadPoolExecutor(max_workers=parallel) as pool:
+            futures = [
+                pool.submit(self._run_in_subprocess, name) for name in tenants
+            ]
+            try:
+                for f in as_completed(futures):
+                    f.result()
+            except SystemExit:
+                for f in futures:
+                    f.cancel()
+                raise
+
+    def run_migrations(self, tenants=None):
+        tenants = list(tenants or [])
+        if self.PUBLIC_SCHEMA_NAME in tenants:
+            # Public is a single schema; running it in-process avoids paying
+            # subprocess startup for the no-leak case.
+            run_migrations(
+                self.args, self.options, self.codename, self.PUBLIC_SCHEMA_NAME
+            )
+            tenants.remove(self.PUBLIC_SCHEMA_NAME)
+        if not tenants:
+            return
+        self._close_connections()
+        parallel = self._max_parallel()
+        if parallel == 1:
+            for schema_name in tenants:
+                self._run_in_subprocess(schema_name)
+            return
+        self._run_parallel(tenants, parallel)
+
+    def run_multi_type_migrations(self, tenants):
+        # Implement analogously to run_migrations if/when needed; see the
+        # multi-type code in MultiprocessingExecutor for argument shape.
+        raise NotImplementedError(
+            "SubprocessExecutor does not yet support multi-type tenants."
+        )

--- a/django_tenants/tests/test_migration_executors.py
+++ b/django_tenants/tests/test_migration_executors.py
@@ -1,0 +1,177 @@
+"""Unit tests for the migration executors, focused on SubprocessExecutor.
+
+These tests mock ``subprocess.run`` at the system boundary so no real
+``migrate_schemas`` child processes are spawned. They assert on how the
+executor selects parallelism, builds the child argv, and propagates failures.
+"""
+
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+from django_tenants.management.commands.migrate_schemas import MigrateSchemasCommand
+from django_tenants.migration_executors import get_executor
+from django_tenants.migration_executors.subproc import SubprocessExecutor
+
+
+SUBPROC = "django_tenants.migration_executors.subproc"
+
+
+def _contains_subsequence(seq, sub):
+    """Return True if ``sub`` appears as a contiguous slice of ``seq``."""
+    n = len(sub)
+    return any(list(seq[i:i + n]) == list(sub) for i in range(len(seq) - n + 1))
+
+
+def make_executor(args=(), **options):
+    options.setdefault("verbosity", 1)
+    return SubprocessExecutor(list(args), options)
+
+
+class SubprocessExecutorRegistrationTests(SimpleTestCase):
+    def test_codename_is_subprocess(self):
+        self.assertEqual(SubprocessExecutor.codename, "subprocess")
+
+    def test_get_executor_resolves_subprocess(self):
+        self.assertIs(get_executor("subprocess"), SubprocessExecutor)
+
+
+class SubprocessExecutorPublicSchemaTests(SimpleTestCase):
+    def test_public_schema_runs_in_process_not_subprocess(self):
+        executor = make_executor()
+        public = executor.PUBLIC_SCHEMA_NAME
+
+        with mock.patch(f"{SUBPROC}.run_migrations") as run_migrations, \
+                mock.patch(f"{SUBPROC}.subprocess.run") as subprocess_run:
+            executor.run_migrations(tenants=[public])
+
+        run_migrations.assert_called_once_with(
+            executor.args, executor.options, executor.codename, public
+        )
+        subprocess_run.assert_not_called()
+
+
+class SubprocessExecutorArgvTests(SimpleTestCase):
+    def test_one_subprocess_per_tenant_with_expected_argv(self):
+        executor = make_executor(
+            args=("myapp",),
+            interactive=False,
+            fake=True,
+            verbosity=2,
+            database="default",
+        )
+
+        completed = mock.Mock(returncode=0)
+        with mock.patch.object(executor, "_close_connections"), \
+                mock.patch(f"{SUBPROC}.subprocess.run", return_value=completed) as run:
+            executor.run_migrations(tenants=["tenant_a", "tenant_b"])
+
+        self.assertEqual(run.call_count, 2)
+        first_cmd = run.call_args_list[0].args[0]
+        second_cmd = run.call_args_list[1].args[0]
+
+        for cmd, schema in ((first_cmd, "tenant_a"), (second_cmd, "tenant_b")):
+            self.assertIn("migrate_schemas", cmd)
+            self.assertIn("--executor=standard", cmd)
+            self.assertTrue(_contains_subsequence(cmd, ["--schema", schema]))
+            self.assertIn("myapp", cmd)
+            self.assertIn("--noinput", cmd)
+            self.assertIn("--fake", cmd)
+            self.assertTrue(_contains_subsequence(cmd, ["--verbosity", "2"]))
+            self.assertTrue(_contains_subsequence(cmd, ["--database", "default"]))
+
+    def test_parallel_flag_not_forwarded_to_child(self):
+        executor = make_executor(parallel=5)
+
+        completed = mock.Mock(returncode=0)
+        with mock.patch(f"{SUBPROC}.subprocess.run", return_value=completed) as run:
+            executor._run_in_subprocess("tenant_a")
+
+        cmd = run.call_args.args[0]
+        self.assertNotIn("--parallel", cmd)
+        self.assertNotIn("5", cmd)
+
+
+class SubprocessExecutorMaxParallelTests(SimpleTestCase):
+    def test_cli_value_takes_precedence(self):
+        executor = make_executor(parallel=4)
+        with override_settings(TENANT_SUBPROCESS_PARALLEL=3):
+            self.assertEqual(executor._max_parallel(), 4)
+
+    def test_setting_used_when_no_cli_value(self):
+        executor = make_executor(parallel=None)
+        with override_settings(TENANT_SUBPROCESS_PARALLEL=3):
+            self.assertEqual(executor._max_parallel(), 3)
+
+    def test_default_is_one(self):
+        executor = make_executor(parallel=None)
+        self.assertEqual(executor._max_parallel(), 1)
+
+    def test_values_are_clamped_to_at_least_one(self):
+        self.assertEqual(make_executor(parallel=0)._max_parallel(), 1)
+        self.assertEqual(make_executor(parallel=-5)._max_parallel(), 1)
+        with override_settings(TENANT_SUBPROCESS_PARALLEL=0):
+            self.assertEqual(make_executor(parallel=None)._max_parallel(), 1)
+
+
+class SubprocessExecutorFailureTests(SimpleTestCase):
+    def test_failing_child_raises_systemexit_and_stops(self):
+        executor = make_executor()
+
+        failing = mock.Mock(returncode=1)
+        with mock.patch.object(executor, "_close_connections"), \
+                mock.patch(f"{SUBPROC}.subprocess.run", return_value=failing) as run:
+            with self.assertRaises(SystemExit) as ctx:
+                executor.run_migrations(tenants=["tenant_a", "tenant_b"])
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(run.call_count, 1)
+
+
+class SubprocessExecutorParallelTests(SimpleTestCase):
+    def test_parallel_failure_cancels_pending_and_propagates(self):
+        executor = make_executor(parallel=2)
+        tenants = ["fail", "slow1", "slow2", "slow3", "slow4", "slow5"]
+        started = []
+        lock = __import__("threading").Lock()
+
+        def fake_run(schema_name):
+            with lock:
+                started.append(schema_name)
+            if schema_name == "fail":
+                raise SystemExit(1)
+            import time
+            time.sleep(0.3)
+
+        with mock.patch.object(executor, "_close_connections"), \
+                mock.patch.object(executor, "_run_in_subprocess", side_effect=fake_run):
+            with self.assertRaises(SystemExit) as ctx:
+                executor.run_migrations(tenants=tenants)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("fail", started)
+        # Cancellation must prevent at least some not-yet-started tenants from
+        # ever launching.
+        self.assertLess(len(started), len(tenants))
+
+
+class MigrateSchemasParallelArgumentTests(SimpleTestCase):
+    def _parse(self, argv):
+        command = MigrateSchemasCommand()
+        parser = command.create_parser("manage.py", "migrate_schemas")
+        return parser.parse_args(argv)
+
+    def test_parallel_defaults_to_none(self):
+        namespace = self._parse([])
+        self.assertIsNone(namespace.parallel)
+
+    def test_parallel_parsed_as_int(self):
+        namespace = self._parse(["--parallel", "4"])
+        self.assertEqual(namespace.parallel, 4)
+
+
+class SubprocessExecutorMultiTypeTests(SimpleTestCase):
+    def test_run_multi_type_migrations_not_implemented(self):
+        executor = make_executor()
+        with self.assertRaises(NotImplementedError):
+            executor.run_multi_type_migrations(tenants=[("schema", "type1")])

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -367,6 +367,54 @@ The ``multiprocessing`` executor accepts the following settings:
   sent at once to every worker
 
 
+migrate_schemas with the subprocess executor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``subprocess`` executor spawns a fresh ``python manage.py migrate_schemas
+--schema <name>`` process for each tenant:
+
+.. code-block:: bash
+
+    python manage.py migrate_schemas --executor=subprocess
+
+Use this when a single-process migrate runs out of memory due to accumulated
+per-tenant state — typically at tens of tenants times hundreds of migrations.
+``migrate_schemas`` normally runs every tenant schema inside one long-lived
+Python process, and per-tenant state (project state, ``post_migrate`` signal
+caches, content types and permissions) is never released, so resident memory
+climbs until the OOM killer reaps the process mid-migration.
+
+Unlike ``multiprocessing``, which forks workers from a parent whose memory
+already includes the full migration graph (and grows further via
+copy-on-write), ``subprocess`` starts each tenant from a clean interpreter,
+guaranteeing resident memory returns to baseline between tenants. The public
+schema is migrated in-process (it is a single schema with no per-tenant
+accumulation), and each child runs with ``--executor=standard`` so there is no
+recursive fan-out.
+
+The first child to exit with a non-zero status stops the run and propagates
+that status as the parent's exit code (this also covers ``--check`` signalling
+pending migrations). In parallel mode, not-yet-started tenants are cancelled
+while any in-flight subprocesses are allowed to drain — an in-flight migration
+cannot be safely killed mid-DDL.
+
+Configure parallelism with ``--parallel N`` on the CLI, or with the
+``TENANT_SUBPROCESS_PARALLEL`` setting:
+
+* ``TENANT_SUBPROCESS_PARALLEL`` (default: 1) - number of tenant migrations to
+  run in parallel. ``--parallel N`` on the CLI overrides this setting. Size it
+  to fit available memory on the host running the migrate, since peak memory is
+  roughly ``N`` times the per-tenant peak.
+
+.. code-block:: bash
+
+    python manage.py migrate_schemas --executor=subprocess --parallel=4
+
+.. note::
+
+    The ``subprocess`` executor does not yet support multi-type tenants.
+
+
 tenant_command
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Summary

Existing executors (`standard`, `multiprocessing`) accumulate per-tenant state across tenants in a single process; `multiprocessing` forks workers that inherit the bloated parent via copy-on-write, so it only partially helps. In deployments with many tenants × many migrations this leads to mid-migrate OOM and partially-applied schema state.

Fixes #1211.

This PR adds `SubprocessExecutor`, which spawns a fresh `python manage.py migrate_schemas --schema <name>` process per tenant. Each child starts from a clean Python interpreter, so RSS returns to baseline between tenants. Configurable parallelism via `--parallel N` (CLI) / `TENANT_SUBPROCESS_PARALLEL` (setting). **Default behavior is unchanged** — the default executor remains `standard`.

## Why `multiprocessing` is insufficient

`MultiprocessingExecutor` uses `multiprocessing.Pool`, which `fork()`s workers from the parent. The parent has already imported all of Django, built the full migration graph, and loaded model state; workers inherit that via copy-on-write and, as each worker mutates pages running its assigned tenants sequentially, COW duplicates those pages. With several workers each accumulating per-tenant leak, peak RSS can be **higher** than single-process `standard`. `subprocess` sidesteps this: each tenant runs in a brand-new interpreter with no inherited parent state.

## What's included

- New executor codename: `subprocess`
- New CLI flag: `--parallel N` on `migrate_schemas`
- New setting: `TENANT_SUBPROCESS_PARALLEL` (default `1`); `--parallel` overrides it
- Public schema migrates in-process (single schema, no per-tenant leak; avoids subprocess startup cost)
- Each child runs with `--executor=standard` — no recursive fan-out
- First non-zero child rc propagates as `SystemExit(rc)` (covers real migrate failures and `--check` signalling pending migrations)
- In parallel mode, not-yet-started tenants are cancelled on first failure; in-flight children drain before exit (a migration cannot be safely killed mid-DDL)
- `run_multi_type_migrations` raises `NotImplementedError` for now

## Usage

```bash
# serial, one fresh process per tenant
python manage.py migrate_schemas --executor=subprocess

# up to 4 tenants migrating concurrently
python manage.py migrate_schemas --executor=subprocess --parallel=4
```

## Tests

Adds `django_tenants/tests/test_migration_executors.py` (14 unit tests) covering: registration under codename `subprocess`, the public in-process path (no subprocess spawned), one child per tenant with the expected argv, `_max_parallel` precedence/clamping, `SystemExit` on failure stopping the loop, parallel cancellation, `--parallel` not being forwarded to children, the `--parallel` argparse wiring, and `run_multi_type_migrations` raising `NotImplementedError`.

Also validated end-to-end against a live PostgreSQL on django-tenants 3.10.1 (Django 6.0, psycopg3): created 3 tenants, unapplied an app, then re-applied it via `--executor=subprocess --parallel=2` (real spawned child processes) and confirmed the migration was applied in all tenants. The full existing suite continues to pass (one unrelated, pre-existing storage deprecation-warning test failure, reproducible on a clean checkout).

## Backwards compatibility

New codename, new setting, new CLI flag. No existing executor or setting changes behavior. `--parallel` is silently ignored by other executors.

## Open questions for reviewers

- **Setting name** — `TENANT_SUBPROCESS_PARALLEL` mirrors `TENANT_MULTIPROCESSING_MAX_PROCESSES`; open to `TENANT_SUBPROCESS_MAX_PROCESSES` for naming consistency.
- **`--parallel` placement** — added unconditionally to `migrate_schemas`; could be rejected for non-`subprocess` executors if a stricter posture is preferred.
- **Multi-type tenants** — left as `NotImplementedError`; trivial to add if required before merge.
