### PR TITLE
Add mypy plugin to declare request.tenant on HttpRequest

### DIFF
--- a/django_tenants/mypy_plugin.py
+++ b/django_tenants/mypy_plugin.py
@@ -1,0 +1,68 @@
+"""
+Mypy plugin for django-tenants.
+
+django-tenants middleware dynamically adds a ``tenant`` attribute to every
+``HttpRequest`` at runtime.  Static type-checkers cannot see this attribute
+because it is not declared on ``HttpRequest``.
+
+This plugin hooks into mypy's class analysis and injects the ``tenant``
+attribute (typed as ``TenantMixin``) into ``HttpRequest`` so that all
+subclasses — including DRF's ``Request`` — inherit it automatically.
+
+Usage — add to ``pyproject.toml``::
+
+    [tool.mypy]
+    plugins = [
+        "django_tenants.mypy_plugin",
+    ]
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from mypy.nodes import MemberExpr
+from mypy.nodes import NameExpr
+from mypy.plugin import ClassDefContext
+from mypy.plugin import Plugin
+from mypy.plugins.common import add_attribute_to_class
+from mypy.types import AnyType
+from mypy.types import TypeOfAny
+from mypy.types import UnionType
+
+HTTPREQUEST_FULLNAME = "django.http.request.HttpRequest"
+TENANT_MIXIN_FULLNAME = "django_tenants.models.TenantMixin"
+
+
+def _resolve_tenant_type(ctx: ClassDefContext) -> AnyType | UnionType:
+    """Try to resolve TenantMixin as the type for ``request.tenant``.
+
+    Falls back to ``Any`` if TenantMixin cannot be looked up yet (e.g.
+    during early semantic-analysis passes).
+    """
+    try:
+        tenant_info = ctx.api.named_type(TENANT_MIXIN_FULLNAME, [])
+        return tenant_info
+    except (AssertionError, KeyError):
+        return AnyType(TypeOfAny.implementation_artifact)
+
+
+def _add_tenant_attribute(ctx: ClassDefContext) -> None:
+    """Add ``tenant: TenantMixin`` to a class that inherits HttpRequest."""
+    tenant_type = _resolve_tenant_type(ctx)
+    add_attribute_to_class(ctx.api, ctx.cls, "tenant", tenant_type)
+
+
+class DjangoTenantsPlugin(Plugin):
+    """Mypy plugin that declares ``request.tenant`` on HttpRequest."""
+
+    def get_base_class_hook(
+        self, fullname: str
+    ) -> Callable[[ClassDefContext], None] | None:
+        if fullname == HTTPREQUEST_FULLNAME:
+            return _add_tenant_attribute
+        return None
+
+
+def plugin(version: str) -> type[Plugin]:
+    return DjangoTenantsPlugin

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -327,6 +327,23 @@ If you put this in the same Django project, you can make a new ``settings_public
 Or you can create a completely separate project for the main website.
 
 
+Mypy Support
+============
+
+django-tenants ships with a mypy plugin that declares the ``tenant`` attribute on ``HttpRequest``. Without it, strict mypy with ``django-stubs >= 6.0`` will report ``attr-defined`` errors on every ``request.tenant`` access.
+
+To enable it, add ``django_tenants.mypy_plugin`` to your mypy plugins in ``pyproject.toml``:
+
+.. code-block:: toml
+
+    [tool.mypy]
+    plugins = [
+        "django_tenants.mypy_plugin",
+    ]
+
+The plugin injects a ``tenant`` attribute (typed as ``TenantMixin``) into ``HttpRequest``, so all subclasses — including DRF's ``Request`` — inherit it automatically.
+
+
 Caching
 =======
 


### PR DESCRIPTION
Closes #1230

## Summary

- Add `django_tenants.mypy_plugin` that injects a `tenant` attribute (typed as `TenantMixin`) into `HttpRequest`
- All subclasses — including DRF's `Request` — inherit it automatically
- Add documentation in `install.rst`

## The problem

With `django-stubs >= 6.0`, strict mypy reports `[attr-defined]` errors on every `request.tenant` access because the attribute is dynamically added by the middleware at runtime and not declared on `HttpRequest`:

```
error: "HttpRequest" has no attribute "tenant"  [attr-defined]
error: "Request" has no attribute "tenant"  [attr-defined]
```

## Usage

```toml
[tool.mypy]
plugins = [
    "django_tenants.mypy_plugin",
]
```

## Test plan

- [x] Tested against a production Django 6.0 + DRF 3.17 project with `django-stubs==6.0.5` and `djangorestframework-stubs==3.17.0`
- [x] Verified 0 mypy errors with the plugin enabled (was 116 `attr-defined` errors without it)
- [x] Plugin gracefully falls back to `Any` type if `TenantMixin` can't be resolved during early analysis passes
