### PR TITLE
Use fork start method in multiprocessing migration executor

### DIFF
--- a/django_tenants/migration_executors/multiproc.py
+++ b/django_tenants/migration_executors/multiproc.py
@@ -6,6 +6,24 @@ from django.conf import settings
 from .base import MigrationExecutor, run_migrations
 
 
+def get_pool():
+    """Return a multiprocessing pool using the ``fork`` start method when available.
+
+    The migration workers rely on inheriting the parent process's already
+    populated Django app registry and settings, which only happens with the
+    ``fork`` start method. Python no longer guarantees ``fork`` as the implicit
+    default (it is deprecated when the parent is multi-threaded), so request it
+    explicitly on platforms that support it (e.g. Linux) and fall back to the
+    default context elsewhere (e.g. Windows, which has no ``fork``).
+    """
+    processes = getattr(settings, 'TENANT_MULTIPROCESSING_MAX_PROCESSES', 2)
+    if 'fork' in multiprocessing.get_all_start_methods():
+        context = multiprocessing.get_context('fork')
+    else:
+        context = multiprocessing.get_context()
+    return context.Pool(processes=processes)
+
+
 def run_migrations_percent(args, options, codename, count, idx_schema_name):
     idx, schema_name = idx_schema_name
     return run_migrations(
@@ -44,11 +62,6 @@ class MultiprocessingExecutor(MigrationExecutor):
             tenants.pop(tenants.index(self.PUBLIC_SCHEMA_NAME))
 
         if tenants:
-            processes = getattr(
-                settings,
-                'TENANT_MULTIPROCESSING_MAX_PROCESSES',
-                2
-            )
             chunks = getattr(
                 settings,
                 'TENANT_MULTIPROCESSING_CHUNKS',
@@ -68,7 +81,7 @@ class MultiprocessingExecutor(MigrationExecutor):
                 self.codename,
                 len(tenants)
             )
-            p = multiprocessing.Pool(processes=processes)
+            p = get_pool()
             p.map(
                 run_migrations_p,
                 enumerate(tenants),
@@ -77,11 +90,6 @@ class MultiprocessingExecutor(MigrationExecutor):
 
     def run_multi_type_migrations(self, tenants):
         tenants = tenants or []
-        processes = getattr(
-            settings,
-            'TENANT_MULTIPROCESSING_MAX_PROCESSES',
-            2
-        )
         chunks = getattr(
             settings,
             'TENANT_MULTIPROCESSING_CHUNKS',
@@ -101,7 +109,7 @@ class MultiprocessingExecutor(MigrationExecutor):
             self.codename,
             len(tenants)
         )
-        p = multiprocessing.Pool(processes=processes)
+        p = get_pool()
         p.map(
             run_migrations_p,
             enumerate(tenants),


### PR DESCRIPTION
## Summary

The `multiprocessing` migration executor's workers import the PostgreSQL backend and touch the Django app registry. That only works if the worker **inherits** the parent's already-populated app registry — i.e. the `fork` start method. With `spawn`/`forkserver` the worker is a fresh interpreter that never ran `django.setup()`, so it fails at `apps.check_apps_ready()`.

The pool previously relied on Python's **implicit** default start method. Python 3.14 now emits a `DeprecationWarning` when implicitly forking from a multi-threaded parent, and a future Python will change the default away from `fork` — which would silently break this executor even on Linux.

## Change

`django_tenants/migration_executors/multiproc.py`:

- New `get_pool()` helper that builds the pool from an explicit `fork` context where the platform supports it (Linux), falling back to the default context elsewhere (e.g. Windows, which has no `fork`).
- Both call sites (`run_migrations`, `run_multi_type_migrations`) now use `get_pool()`.
- `get_context('fork')` returns a local context object and does **not** mutate the global default start method, so nothing else in the process is affected.
- `TENANT_MULTIPROCESSING_MAX_PROCESSES` / `TENANT_MULTIPROCESSING_CHUNKS` behavior is unchanged.

## Testing

- Verified the standard executor passes all 98 tests against Django 6.0.6 / Postgres 17.
- Module parses and imports cleanly under Django 6.0.6.
- The `multiprocessing` executor path is validated by the existing CI matrix (Linux), which is what this PR exercises. It was not re-run locally because forking on macOS deadlocks (a macOS fork-with-threads hazard unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)