### PR TITLE
Resolve the destination's own identity sequences when cloning

### DIFF
--- a/django_tenants/clone.py
+++ b/django_tenants/clone.py
@@ -2966,15 +2966,26 @@ BEGIN
       IF bDebug THEN RAISE NOTICE 'DEBUG: Section=%',action; END IF;
       cnt := 0;
       setcnt := 0;
-      -- NOTE: we can infer an identity type sequence if it is in the pg_sequences table, but not the information_schema.sequences table.
+      -- NOTE: identity columns are found through pg_depend rather than by name.  A sequence's name is
+      -- derived from its table when the column is created and is never revisited, so ALTER TABLE ...
+      -- RENAME leaves the sequence under the table's old name.  The destination's sequences are made
+      -- fresh by CREATE TABLE ... (LIKE ... INCLUDING ALL) and so are named after the current table:
+      -- the two names diverge for any renamed table, and reusing the source's name would target a
+      -- sequence that does not exist in the destination.  Resolve the destination's own sequence from
+      -- the table and column instead, falling back to the source's name when the destination table is
+      -- absent (DDL-only runs) so the reported SQL still names something.
       FOR object, sq_last_value IN
-        -- Isssue#140
-        -- SELECT sequencename::text, COALESCE(last_value, -999) from pg_sequences where schemaname = quote_ident(source_schema)
-        SELECT sequencename::text, COALESCE(last_value, -999) from pg_sequences where schemaname = source_schema
-        AND NOT EXISTS
-        -- Isssue#140
-        -- (select 1 from information_schema.sequences where sequence_schema = quote_ident(source_schema) and sequence_name = sequencename)
-        (select 1 from information_schema.sequences where sequence_schema = source_schema and sequence_name = sequencename)
+        SELECT COALESCE(
+                 pg_get_serial_sequence(quote_ident(dest_schema) || '.' || quote_ident(t.relname), a.attname),
+                 quote_ident(dest_schema) || '.' || quote_ident(s.relname)
+               )::text,
+               COALESCE(pg_sequence_last_value(s.oid), -999)
+        FROM pg_class s
+        JOIN pg_namespace n ON n.oid = s.relnamespace
+        JOIN pg_depend d ON d.objid = s.oid AND d.classid = 'pg_class'::regclass AND d.deptype IN ('a', 'i')
+        JOIN pg_class t ON t.oid = d.refobjid
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid
+        WHERE s.relkind = 'S' AND n.nspname = source_schema AND a.attidentity <> ''
       LOOP
         cnt := cnt + 1;
         IF sq_last_value = -999 THEN
@@ -2982,7 +2993,8 @@ BEGIN
           continue;
         END IF;
         setcnt := setcnt + 1;
-        buffer := quote_ident(dest_schema) || '.' || quote_ident(object);
+        -- already schema-qualified and quoted
+        buffer := object;
         IF bData THEN
           lastsql = 'SELECT setval( ''' || buffer || ''', ' || sq_last_value || ', ' || sq_is_called || ');' ;
           IF bDebugExec THEN RAISE NOTICE 'EXEC: %', lastsql; END IF;

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -652,6 +652,50 @@ class CloneSchemaTest(BaseTestCase):
 
             DummyModel(name='Moderator').save()
 
+    def test_clone_schema_where_an_identity_sequence_name_does_not_match_its_table(self):
+        """
+        Exercises the scenario where a table's IDENTITY sequence is not named after the table
+        that owns it. Postgres derives the sequence name when the column is created and never
+        revisits it, so ``ALTER TABLE ... RENAME`` -- i.e. any Django ``RenameModel`` -- leaves
+        the sequence behind under the table's old name.
+
+        The destination's sequences are created fresh by ``CREATE TABLE ... (LIKE ...
+        INCLUDING ALL)``, so they are named after the *current* table. Assuming the source's
+        sequence name also exists in the destination therefore fails with
+        ``relation "<dest>.<old name>_id_seq" does not exist``.
+        """
+        Client = get_tenant_model()
+        tenant = Client(schema_name='s2')
+        tenant.save()
+
+        domain = get_tenant_domain_model()(tenant=tenant, domain='s2.test.com')
+        domain.save()
+
+        with tenant_context(tenant):
+            DummyModel(name='Administrator').save()
+            DummyModel(name='Tester').save()
+
+        table = DummyModel._meta.db_table
+        with connection.cursor() as cursor:
+            # Reproduce the state a historical RenameModel leaves behind: the identity
+            # sequence keeps the name it was given under the model's old table name.
+            cursor.execute(
+                "ALTER SEQUENCE s2.%s RENAME TO legacy_dummy_id_seq" % (table + '_id_seq')
+            )
+
+        clone_schema = CloneSchema()
+        clone_schema.clone_schema(base_schema_name='s2', new_schema_name='d2')
+
+        self.assertTrue(schema_exists('d2'))
+
+        # The clone's sequence must carry the source's last value over, otherwise inserting
+        # into the clone re-uses primary keys that the cloned rows already occupy.
+        with schema_context('d2'):
+            self.assertEqual(DummyModel.objects.count(), 2)
+            moderator = DummyModel(name='Moderator')
+            moderator.save()
+            self.assertEqual(moderator.pk, 3)
+
 
 class SchemaMigratedSignalTest(BaseTestCase):
 


### PR DESCRIPTION
## The bug

`clone_schema` fails on any schema containing a table that has ever been renamed:

```
Action: Identity updating
relation "<dest>.<old table name>_id_seq" does not exist
LastSQL=SELECT setval('<dest>.<old table name>_id_seq', 8, true);
```

The "Identity updating" section takes each identity sequence's name from the source schema and assumes a sequence of that name exists in the destination:

```sql
buffer := quote_ident(dest_schema) || '.' || quote_ident(object);  -- object = the SOURCE's sequence name
EXECUTE 'SELECT setval(''' || buffer || ''', ' || sq_last_value || ', ' || sq_is_called || ');';
```

Postgres derives a sequence's name from its table when the column is created and never revisits it, so `ALTER TABLE ... RENAME` — i.e. any Django `RenameModel` — leaves the sequence behind under the table's old name. The destination's sequences, by contrast, are created fresh by `CREATE TABLE ... (LIKE ... INCLUDING ALL)` and so are named after the *current* table. Minimal demonstration:

```
source seq: old_name_id_seq  table: new_name     <- renamed table keeps the stale sequence name
dest   seq: new_name_id_seq  table: new_name     <- LIKE INCLUDING ALL names it fresh
```

The names therefore diverge for every renamed table, and the clone dies on the first one that holds data. Sequences that were never incremented are skipped by the existing `-999` guard, which is why this shows up as "clone worked yesterday, fails today". On the schema where I hit it, 41 of 349 identity sequences were affected.

## The fix

Find identity columns through `pg_depend` and resolve the destination's own sequence with `pg_get_serial_sequence(dest_table, column)`, rather than reusing the source's name. Falls back to the source's name only for DDL-only runs, where there is no destination table and no data to set anyway.

Selecting on `attidentity` also states directly what the `NOT EXISTS` against `information_schema.sequences` was inferring.

## Tests

Adds `test_clone_schema_where_an_identity_sequence_name_does_not_match_its_table`. It reproduces the divergence with `ALTER SEQUENCE ... RENAME`, which leaves exactly the state Postgres leaves after a table rename, and asserts the consequence rather than just the absence of a crash: the clone's next insert must get pk 3 rather than colliding with a cloned row.

The test fails on master with the error above and passes with the fix. Full suite green, and I verified the fix end to end against a real 462-table tenant schema: all 349 identity sequences land on the source's value, 0 mismatches.
