### PR TITLE
Release prep for 3.11.0: PyPI publish workflow, version bump, review follow-ups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: release
+
+# Publishes to PyPI when a GitHub release is published, using PyPI trusted
+# publishing (OIDC) -- no API token is stored in the repository.
+#
+# One-time setup on PyPI (https://pypi.org/manage/project/django-tenants/settings/publishing/):
+#   Owner:            django-tenants
+#   Repository:       django-tenants
+#   Workflow name:    release.yml
+#   Environment:      pypi
+# The environment name below must match the one configured there.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:  # lets you dry-run the build without publishing
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Build sdist and wheel
+      run: |
+        python -m pip install --upgrade build twine
+        python -m build
+        python -m twine check --strict dist/*
+
+    # A tag that disagrees with pyproject.toml would publish the wrong version
+    # under the right name, which cannot be undone on PyPI.
+    - name: Check the tag matches the project version
+      if: github.event_name == 'release'
+      run: |
+        project_version=$(python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+        tag_version="${GITHUB_REF_NAME#v}"
+        echo "pyproject.toml: $project_version"
+        echo "git tag:        $tag_version  (from $GITHUB_REF_NAME)"
+        if [ "$project_version" != "$tag_version" ]; then
+          echo "::error::Tag '$GITHUB_REF_NAME' does not match pyproject.toml version '$project_version'."
+          exit 1
+        fi
+
+    - name: List what will be published
+      run: ls -l dist/
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+        if-no-files-found: error
+
+  pypi:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/django-tenants
+    permissions:
+      id-token: write  # required for trusted publishing; nothing else is granted
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: dist
+        path: dist/
+
+    - uses: pypa/gh-action-pypi-publish@release/v1

--- a/django_tenants/clone.py
+++ b/django_tenants/clone.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import connection, transaction
+from django.db import connection
 
 from django_tenants.utils import schema_exists
 
@@ -4594,10 +4594,11 @@ class CloneSchema:
             connection.set_schema_to_public()
         cursor = connection.cursor()
 
-
-        # create or update the clone_schema function in the db
+        # create or update the clone_schema function in the db. CREATE OR REPLACE FUNCTION is
+        # idempotent and visible to the statements that follow, inside a transaction or not, so
+        # this needs no commit of its own -- and committing here would raise
+        # TransactionManagementError when the caller is inside an atomic block (#1155, #694).
         self._create_clone_schema_function()
-
 
         if schema_exists(new_schema_name):
             raise ValidationError("New schema name already exists")

--- a/django_tenants/migration_executors/subproc.py
+++ b/django_tenants/migration_executors/subproc.py
@@ -15,6 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.db import connections
 
 from .base import MigrationExecutor, run_migrations
@@ -52,13 +53,39 @@ def _options_to_argv(options: dict) -> list[str]:
     verbosity = options.get("verbosity", 1)
     if verbosity != 1:
         argv += ["--verbosity", str(verbosity)]
+    # These two decide which settings the child loads at all. A parent invoked as
+    # `manage.py migrate_schemas --settings=myproject.settings.production` would otherwise
+    # spawn children that fall back to DJANGO_SETTINGS_MODULE -- quietly migrating against a
+    # different database than the one asked for.
+    if options.get("settings"):
+        argv += ["--settings", options["settings"]]
+    if options.get("pythonpath"):
+        argv += ["--pythonpath", options["pythonpath"]]
     return argv
 
 
 def _manage_py() -> str:
+    """Locate the manage.py to spawn children with.
+
+    Raises rather than handing subprocess a path that isn't there: when this executor is
+    driven by something other than ``manage.py`` (``django-admin``, ``call_command()`` from
+    application or task code, a test runner) ``sys.argv[0]`` points elsewhere and the cwd
+    fallback need not contain a manage.py. Failing here says what is wrong; failing in the
+    child surfaces as an opaque interpreter error once per tenant.
+    """
     if sys.argv and sys.argv[0].endswith("manage.py"):
-        return str(Path(sys.argv[0]).resolve())
-    return str(Path("manage.py").resolve())
+        candidate = Path(sys.argv[0]).resolve()
+    else:
+        candidate = Path("manage.py").resolve()
+    if not candidate.is_file():
+        raise ImproperlyConfigured(
+            "The subprocess executor spawns 'manage.py migrate_schemas' per tenant, but no "
+            "manage.py could be found (looked for {}). This happens when migrate_schemas is "
+            "not run through manage.py -- via django-admin, or call_command() from "
+            "application code. Use --executor=standard or --executor=multiprocessing "
+            "instead, or run migrate_schemas through manage.py.".format(candidate)
+        )
+    return str(candidate)
 
 
 class SubprocessExecutor(MigrationExecutor):

--- a/django_tenants/mypy_plugin.py
+++ b/django_tenants/mypy_plugin.py
@@ -21,20 +21,18 @@ from __future__ import annotations
 
 from typing import Callable
 
-from mypy.nodes import MemberExpr
-from mypy.nodes import NameExpr
 from mypy.plugin import ClassDefContext
 from mypy.plugin import Plugin
 from mypy.plugins.common import add_attribute_to_class
 from mypy.types import AnyType
+from mypy.types import Instance
 from mypy.types import TypeOfAny
-from mypy.types import UnionType
 
 HTTPREQUEST_FULLNAME = "django.http.request.HttpRequest"
 TENANT_MIXIN_FULLNAME = "django_tenants.models.TenantMixin"
 
 
-def _resolve_tenant_type(ctx: ClassDefContext) -> AnyType | UnionType:
+def _resolve_tenant_type(ctx: ClassDefContext) -> Instance | AnyType:
     """Try to resolve TenantMixin as the type for ``request.tenant``.
 
     Falls back to ``Any`` if TenantMixin cannot be looked up yet (e.g.

--- a/django_tenants/tests/test_migration_executors.py
+++ b/django_tenants/tests/test_migration_executors.py
@@ -91,6 +91,65 @@ class SubprocessExecutorArgvTests(SimpleTestCase):
         self.assertNotIn("--parallel", cmd)
         self.assertNotIn("5", cmd)
 
+    def test_settings_and_pythonpath_are_forwarded(self):
+        # These decide which settings the child loads at all. Dropping them means a parent run
+        # with --settings=... spawns children that fall back to DJANGO_SETTINGS_MODULE, and
+        # migrate against a different database than the one asked for.
+        executor = make_executor(
+            settings="myproject.settings.production", pythonpath="/srv/app"
+        )
+
+        completed = mock.Mock(returncode=0)
+        with mock.patch(f"{SUBPROC}.subprocess.run", return_value=completed) as run:
+            executor._run_in_subprocess("tenant_a")
+
+        cmd = run.call_args.args[0]
+        self.assertTrue(
+            _contains_subsequence(cmd, ["--settings", "myproject.settings.production"])
+        )
+        self.assertTrue(_contains_subsequence(cmd, ["--pythonpath", "/srv/app"]))
+
+    def test_settings_and_pythonpath_are_omitted_when_unset(self):
+        executor = make_executor()
+
+        completed = mock.Mock(returncode=0)
+        with mock.patch(f"{SUBPROC}.subprocess.run", return_value=completed) as run:
+            executor._run_in_subprocess("tenant_a")
+
+        cmd = run.call_args.args[0]
+        self.assertNotIn("--settings", cmd)
+        self.assertNotIn("--pythonpath", cmd)
+
+
+class ManagePyLookupTests(SimpleTestCase):
+    """``_manage_py()`` must fail loudly rather than hand subprocess a path that isn't there.
+
+    Without this the executor spawns a missing file once per tenant, and the operator sees an
+    opaque interpreter error instead of being told which executor to use.
+    """
+
+    def test_uses_sys_argv_when_run_through_manage_py(self):
+        from django_tenants.migration_executors.subproc import _manage_py
+
+        with mock.patch(f"{SUBPROC}.sys.argv", ["/srv/app/manage.py", "migrate_schemas"]), \
+                mock.patch(f"{SUBPROC}.Path.is_file", return_value=True):
+            self.assertTrue(_manage_py().endswith("manage.py"))
+
+    def test_raises_when_no_manage_py_can_be_found(self):
+        from django.core.exceptions import ImproperlyConfigured
+
+        from django_tenants.migration_executors.subproc import _manage_py
+
+        with mock.patch(f"{SUBPROC}.sys.argv", ["django-admin", "migrate_schemas"]), \
+                mock.patch(f"{SUBPROC}.Path.is_file", return_value=False):
+            with self.assertRaises(ImproperlyConfigured) as ctx:
+                _manage_py()
+
+        message = str(ctx.exception)
+        self.assertIn("manage.py", message)
+        # Must point at the way out, not just report the failure.
+        self.assertIn("--executor=standard", message)
+
 
 class SubprocessExecutorMaxParallelTests(SimpleTestCase):
     def test_cli_value_takes_precedence(self):

--- a/django_tenants/tests/test_mypy_plugin.py
+++ b/django_tenants/tests/test_mypy_plugin.py
@@ -1,0 +1,46 @@
+"""Smoke tests for the mypy plugin (django_tenants/mypy_plugin.py).
+
+The plugin is only ever imported by mypy, never by Django at runtime, so nothing else in the
+suite touches it. It leans on ``mypy.plugins.common.add_attribute_to_class``, which is not a
+stable public API -- without these, a mypy release that moves it would ship broken and only be
+noticed by users. Skipped when mypy is absent so the suite still runs without the dev extras.
+"""
+
+from unittest import skipUnless
+
+from django.test import SimpleTestCase
+
+try:
+    import mypy  # noqa: F401
+
+    HAS_MYPY = True
+except ImportError:
+    HAS_MYPY = False
+
+
+@skipUnless(HAS_MYPY, 'mypy is not installed')
+class MypyPluginTestCase(SimpleTestCase):
+    def test_plugin_entrypoint_returns_the_plugin_class(self):
+        from django_tenants.mypy_plugin import DjangoTenantsPlugin, plugin
+
+        self.assertIs(plugin('1.0'), DjangoTenantsPlugin)
+
+    def test_hook_is_registered_for_httprequest_only(self):
+        from django_tenants.mypy_plugin import (
+            HTTPREQUEST_FULLNAME,
+            DjangoTenantsPlugin,
+            _add_tenant_attribute,
+        )
+
+        instance = DjangoTenantsPlugin.__new__(DjangoTenantsPlugin)
+        self.assertIs(
+            instance.get_base_class_hook(HTTPREQUEST_FULLNAME), _add_tenant_attribute
+        )
+        self.assertIsNone(instance.get_base_class_hook('django.db.models.Model'))
+
+    def test_the_mypy_apis_the_plugin_depends_on_still_exist(self):
+        # The actual breakage risk: these are internal mypy APIs.
+        from mypy.plugin import ClassDefContext, Plugin  # noqa: F401
+        from mypy.plugins.common import add_attribute_to_class
+
+        self.assertTrue(callable(add_attribute_to_class))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=61" ]
 
 [project]
 name = "django-tenants"
-version = "3.10.2"
+version = "3.11.0"
 description = "Tenant support for Django using PostgreSQL schemas."
 readme = "README.rst"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 optional-dependencies.dev = [
   "coverage",
   "gunicorn==26.0.0",
+  "mypy",  # django_tenants/mypy_plugin.py imports mypy's plugin API
   "psycopg>=3.2.1,<3.3",
 ]
 urls."Homepage" = "https://github.com/django-tenants/django-tenants"


### PR DESCRIPTION
Release prep for 3.11.0, plus follow-ups on the contributions merged for it.

## A PyPI release workflow

Publishing a GitHub release did nothing beyond tagging — `code.yml` only runs tests on `pull_request` and `push: master`, so there was no path from a release to PyPI.

`release.yml` builds the sdist and wheel, runs `twine check --strict`, and publishes on a published release using **PyPI trusted publishing** (OIDC), so no API token is stored in the repository. The build job also refuses to publish when the git tag disagrees with the version in `pyproject.toml` — the wrong version under the right name cannot be undone on PyPI. `workflow_dispatch` builds without publishing, for a dry run.

**This needs one-time setup on PyPI before the first release**, at https://pypi.org/manage/project/django-tenants/settings/publishing/:

| Field | Value |
|---|---|
| Owner | `django-tenants` |
| Repository | `django-tenants` |
| Workflow name | `release.yml` |
| Environment | `pypi` |

Without it the publish job fails at the OIDC exchange. The same values are recorded in a comment at the top of the workflow.

Version bumped to 3.11.0.

## Follow-ups on the merged PRs

Kept in a separate commit from the authors' work.

**#1150** (clone_schema inside atomic) — removed the `transaction` import it orphaned and the blank lines it left behind, and recorded why no commit belongs at that point so it doesn't get added back.

**#1231** (mypy plugin) — removed two unused imports (`MemberExpr`, `NameExpr`), corrected the return annotation on `_resolve_tenant_type` (it returns an `Instance`, never a `UnionType`), added `mypy` to the dev extras, and added smoke tests. The plugin depends on `mypy.plugins.common.add_attribute_to_class`, which is not stable public API, and nothing in the suite imported the module — so a mypy release that moved it would have shipped broken and only been noticed by users. The tests skip when mypy is absent.

**#1228** (subprocess executor) — two hardening fixes:

- `_manage_py()` fell back to `Path("manage.py").resolve()` against the current working directory with no existence check. Driven by `django-admin` or `call_command()` from application code, that hands `subprocess` a path that isn't there and surfaces as an opaque interpreter error once per tenant. It now raises `ImproperlyConfigured` naming the path it looked for and the executors that do work.
- `_options_to_argv()` now forwards `--settings` and `--pythonpath`. A parent invoked as `manage.py migrate_schemas --settings=myproject.settings.production` was spawning children that fell back to `DJANGO_SETTINGS_MODULE` — quietly migrating against a different database than the one asked for.

## Verification

`./run_tests.sh` against a pristine PostgreSQL 17, as CI runs it:

```
exit=0
  standard         Ran 115 tests  OK
  multiprocessing  Ran 115 tests  OK
  integration      create public / empty schema, execute clone_tenant  OK
```

`python -m build` plus `twine check --strict` pass on both artifacts, and the wheel now contains only `django_tenants` (74 files) — no `docs`, `examples` or `dts_test_project`, confirming #1224 — with the three admin templates still present.
