### PR TITLE
Bump version to 3.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=61" ]
 
 [project]
 name = "django-tenants"
-version = "3.11.0"
+version = "3.12.0"
 description = "Tenant support for Django using PostgreSQL schemas."
 readme = "README.rst"
 license = "MIT"


### PR DESCRIPTION
Sets the version for the release.

3.11.x is unusable here: the `v3.11.2` tag already exists and points at `51d6ef3` ("Bump version to 3.10.2"), so it contains 3.10.2 code and was never published — PyPI's latest is still 3.10.2. Numbering this release 3.11.0 would sort *below* that tag, leaving GitHub showing `v3.11.2` as Latest while it carries older code than the newer tag.

3.12.0 is unambiguous against every existing tag and reads as the feature release this is.