### PR TITLE
Quote role names in cloned DDL (#1189), and cover cloning inside atomic (#1155, #694)

### DIFF
--- a/django_tenants/clone.py
+++ b/django_tenants/clone.py
@@ -425,7 +425,8 @@ $$
 
     -- Issue#27: set owner ACL info
     IF aclownercnt = 1 OR acldclcnt = 1 THEN
-        v_acl = 'ALTER TABLE IF EXISTS ' || quote_ident(in_schema) || '.' || quote_ident(in_table) || ' OWNER TO ' || v_owner || ';' || E'\n' || E'\n';
+        -- Issue#1189: v_owner is raw from pg_get_userbyid, so quote it.
+        v_acl = 'ALTER TABLE IF EXISTS ' || quote_ident(in_schema) || '.' || quote_ident(in_table) || ' OWNER TO ' || quote_ident(v_owner) || ';' || E'\n' || E'\n';
     END IF;
 
     -- Issue#35: add all other ACL info if directed
@@ -1439,7 +1440,9 @@ BEGIN
         -- Issue#131: double quote schema names
         -- EXECUTE 'CREATE SCHEMA ' || quote_ident(dest_schema) || ' AUTHORIZATION ' || buffer;
         -- EXECUTE 'CREATE SCHEMA ' || quote_ident(dest_schema) || ' AUTHORIZATION ' || quote_ident(buffer);
-        lastsql = 'CREATE SCHEMA ' || quote_ident(dest_schema) || ' AUTHORIZATION ' || buffer;
+        -- Issue#1189: quote the role, as the bDDLOnly branch above already does. An unquoted
+        -- role name containing a hyphen (or anything else needing quoting) is a syntax error.
+        lastsql = 'CREATE SCHEMA ' || quote_ident(dest_schema) || ' AUTHORIZATION ' || quote_ident(buffer);
         IF bDebugExec THEN RAISE NOTICE 'EXEC: %',lastsql; END IF;
         EXECUTE lastsql;
         lastsql = '';
@@ -1748,7 +1751,7 @@ BEGIN
       RAISE INFO '%', 'CREATE SEQUENCE ' || quote_ident(dest_schema) || '.' || quote_ident(seqname) || ';';
       IF NOT bNoOwner THEN
         -- Fixed Issue#108: double-quote roles in case they have special characters
-        RAISE INFO '%', 'ALTER  SEQUENCE ' || quote_ident(dest_schema) || '.' || quote_ident(seqname) || ' OWNER TO ' || seqowner || ';';
+        RAISE INFO '%', 'ALTER  SEQUENCE ' || quote_ident(dest_schema) || '.' || quote_ident(seqname) || ' OWNER TO ' || quote_ident(seqowner) || ';';
       END IF;
     ELSE
       lastsql = 'CREATE SEQUENCE ' || quote_ident(dest_schema) || '.' || quote_ident(seqname) || ';';
@@ -1759,7 +1762,9 @@ BEGIN
 
       -- issue#95
       IF NOT bNoOwner THEN
-        lastsql = 'ALTER SEQUENCE '  || quote_ident(dest_schema) || '.' || quote_ident(seqname) || ' OWNER TO ' || seqowner;
+        -- Issue#1189: seqowner comes back raw from pg_get_userbyid, unlike tblowner which the
+        -- SELECT already double-quotes, so it needs quoting here.
+        lastsql = 'ALTER SEQUENCE '  || quote_ident(dest_schema) || '.' || quote_ident(seqname) || ' OWNER TO ' || quote_ident(seqowner);
         -- RAISE NOTICE 'DEBUGGGG: EXEC: %', lastsql;
         IF bDebugExec THEN RAISE NOTICE 'EXEC: %', lastsql; END IF;
         -- Fixed Issue#108: double-quote roles in case they have special characters

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -696,6 +696,78 @@ class CloneSchemaTest(BaseTestCase):
             moderator.save()
             self.assertEqual(moderator.pk, 3)
 
+    def test_clone_schema_inside_an_atomic_block(self):
+        """``clone_schema`` must be callable from inside ``transaction.atomic()``.
+
+        It used to call ``transaction.commit()``, which raises
+        ``TransactionManagementError`` inside an atomic block -- so cloning was impossible
+        from anything that wraps its work in a transaction: the Django admin's
+        ``save_model``, a view under ``ATOMIC_REQUESTS``, or a plain ``TestCase``.
+        See issues #1155 and #694.
+        """
+        Client = get_tenant_model()
+        tenant = Client(schema_name='s3')
+        tenant.save()
+
+        domain = get_tenant_domain_model()(tenant=tenant, domain='s3.test.com')
+        domain.save()
+
+        with tenant_context(tenant):
+            DummyModel(name='Administrator').save()
+
+        with transaction.atomic():
+            CloneSchema().clone_schema(base_schema_name='s3', new_schema_name='d3')
+
+        self.assertTrue(schema_exists('d3'))
+        with schema_context('d3'):
+            self.assertTrue(DummyModel.objects.filter(name='Administrator').exists())
+
+    def test_clone_schema_owned_by_a_role_whose_name_needs_quoting(self):
+        """Role names are interpolated into DDL and must be quoted.
+
+        A role containing a hyphen is a syntax error unquoted, so cloning a schema owned by
+        one failed on ``CREATE SCHEMA ... AUTHORIZATION``. See issue #1189.
+        """
+        role = 'dts-role-with-hyphen'
+        with connection.cursor() as cursor:
+            try:
+                cursor.execute('CREATE ROLE "%s"' % role)
+            except Exception as e:  # noqa: BLE001 - needs CREATEROLE, which not every CI user has
+                self.skipTest('cannot create a test role: %s' % e)
+        self.addCleanup(self._drop_role, role)
+
+        Client = get_tenant_model()
+        tenant = Client(schema_name='s4')
+        tenant.save()
+        get_tenant_domain_model()(tenant=tenant, domain='s4.test.com').save()
+
+        with tenant_context(tenant):
+            DummyModel(name='Administrator').save()
+
+        with connection.cursor() as cursor:
+            cursor.execute('ALTER SCHEMA s4 OWNER TO "%s"' % role)
+            # A standalone sequence too: seqowner comes back unquoted from pg_get_userbyid,
+            # where tblowner is already double-quoted by its SELECT. An identity sequence
+            # cannot be reowned separately from its table, hence a free-standing one.
+            cursor.execute('CREATE SEQUENCE s4.standalone_seq')
+            cursor.execute('ALTER SEQUENCE s4.standalone_seq OWNER TO "%s"' % role)
+
+        CloneSchema().clone_schema(base_schema_name='s4', new_schema_name='d4')
+
+        self.assertTrue(schema_exists('d4'))
+        with schema_context('d4'):
+            self.assertTrue(DummyModel.objects.filter(name='Administrator').exists())
+
+    @staticmethod
+    def _drop_role(role):
+        connection.set_schema_to_public()
+        with connection.cursor() as cursor:
+            for schema in ('s4', 'd4'):
+                cursor.execute('DROP SCHEMA IF EXISTS %s CASCADE' % schema)
+            cursor.execute('REASSIGN OWNED BY "%s" TO CURRENT_USER' % role)
+            cursor.execute('DROP OWNED BY "%s"' % role)
+            cursor.execute('DROP ROLE IF EXISTS "%s"' % role)
+
 
 class SchemaMigratedSignalTest(BaseTestCase):
 


### PR DESCRIPTION
Two issues in `clone_schema`.

## #1189 — role names interpolated unquoted

Three places build DDL with a raw role name from `pg_get_userbyid`, so a role whose name needs quoting (a hyphen being the common case) produces a syntax error:

```
CREATE SCHEMA q_dst AUTHORIZATION q-hyphen-role
                                   ^ syntax error at or near "-"
```

- `CREATE SCHEMA ... AUTHORIZATION` — the one the reporter hit. The `bDDLOnly` branch immediately above it already applies `quote_ident` (Issue#131), so this was a missed spot rather than a deliberate difference.
- `ALTER SEQUENCE ... OWNER TO` — `seqowner` comes back raw.
- `ALTER TABLE ... OWNER TO` in `pg_get_tabledef` — `v_owner` comes back raw.

Table and type owners are deliberately left alone: their `SELECT`s already wrap the value in double quotes (Issue#108), so applying `quote_ident` again would double it.

## #1155 and #694 — cloning inside `transaction.atomic()`

Fixed by #1150, but that shipped without a test, so nothing would stop `transaction.commit()` being reintroduced. Adds one that clones inside an atomic block — the case that broke cloning from the Django admin, from a view under `ATOMIC_REQUESTS`, and from a plain `TestCase`.

## Verification

Both new tests fail on the unfixed code and pass with it:

| Reverted | Failure |
|---|---|
| the `quote_ident` on `AUTHORIZATION` | `42601 syntax error at or near "-"` |
| the `transaction.commit()` removal | `TransactionManagementError: This is forbidden when an 'atomic' block is active.` |

Full suite: 122 tests, OK.

The role test needs `CREATEROLE` and skips itself if the database user doesn't have it.

Closes #1189. Closes #1155. Closes #694.