### PR TITLE
Use STORAGES in the test project and examples (#1095, #1173)

### DIFF
--- a/docs/files.rst
+++ b/docs/files.rst
@@ -122,7 +122,7 @@ Configuring media file storage
 
 The default Django behavior is to store all files that are uploaded by users in one folder. The path for this upload folder can be configured via the standard ``MEDIA_ROOT`` setting.
 
-The above behaviour can be changed for multi-tenant setups so that each tenant will have a dedicated sub-directory for storing user-uploaded files. To do this simply change ``DEFAULT_FILE_STORAGE`` so that ``TenantFileSystemStorage`` replaces the standard ``FileSystemStorage`` handler:
+The above behaviour can be changed for multi-tenant setups so that each tenant will have a dedicated sub-directory for storing user-uploaded files. To do this point the ``default`` entry of ``STORAGES`` at ``TenantFileSystemStorage`` so that it replaces the standard ``FileSystemStorage`` handler:
 
 .. code-block:: python
 

--- a/dts_test_project/dts_test_project/settings.py
+++ b/dts_test_project/dts_test_project/settings.py
@@ -57,8 +57,16 @@ MULTITENANT_STATICFILES_DIRS = [
     os.path.join(TENANT_APPS_DIR, "tenants/%s/static")
 ]
 
-STATICFILES_STORAGE = "django_tenants.staticfiles.storage.TenantStaticFilesStorage"
-DEFAULT_FILE_STORAGE = "django_tenants.files.storage.TenantFileSystemStorage"
+# STATICFILES_STORAGE and DEFAULT_FILE_STORAGE were deprecated in Django 4.2 and removed in
+# 5.1, where they are ignored -- so the tenant-aware backends silently were not in use.
+STORAGES = {
+    "default": {
+        "BACKEND": "django_tenants.files.storage.TenantFileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django_tenants.staticfiles.storage.TenantStaticFilesStorage",
+    },
+}
 
 MULTITENANT_TEMPLATE_DIRS = [
     os.path.join(TENANT_APPS_DIR, "tenants/%s/templates")

--- a/examples/tenant_multi_types/tenant_multi_types_tutorial/settings.py
+++ b/examples/tenant_multi_types/tenant_multi_types_tutorial/settings.py
@@ -225,7 +225,12 @@ LOGGING = {
     }
 }
 
-DEFAULT_FILE_STORAGE = "django_tenants.files.storage.TenantFileSystemStorage"
+# DEFAULT_FILE_STORAGE was deprecated in Django 4.2 and removed in 5.1.
+STORAGES = {
+    "default": {
+        "BACKEND": "django_tenants.files.storage.TenantFileSystemStorage",
+    },
+}
 MULTITENANT_RELATIVE_MEDIA_ROOT = "uploaded_files"
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 

--- a/examples/tenant_subfolder_tutorial/tenant_subfolder_tutorial/settings.py
+++ b/examples/tenant_subfolder_tutorial/tenant_subfolder_tutorial/settings.py
@@ -209,6 +209,11 @@ LOGGING = {
     }
 }
 
-DEFAULT_FILE_STORAGE = "django_tenants.files.storage.TenantFileSystemStorage"
+# DEFAULT_FILE_STORAGE was deprecated in Django 4.2 and removed in 5.1.
+STORAGES = {
+    "default": {
+        "BACKEND": "django_tenants.files.storage.TenantFileSystemStorage",
+    },
+}
 MULTITENANT_RELATIVE_MEDIA_ROOT = "uploaded_files"
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/examples/tenant_tutorial/tenant_tutorial/settings.py
+++ b/examples/tenant_tutorial/tenant_tutorial/settings.py
@@ -207,6 +207,11 @@ LOGGING = {
     }
 }
 
-DEFAULT_FILE_STORAGE = "django_tenants.files.storage.TenantFileSystemStorage"
+# DEFAULT_FILE_STORAGE was deprecated in Django 4.2 and removed in 5.1.
+STORAGES = {
+    "default": {
+        "BACKEND": "django_tenants.files.storage.TenantFileSystemStorage",
+    },
+}
 MULTITENANT_RELATIVE_MEDIA_ROOT = "uploaded_files"
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'


### PR DESCRIPTION
`DEFAULT_FILE_STORAGE` and `STATICFILES_STORAGE` were deprecated in Django 4.2 and **removed in 5.1**, where they are silently ignored. The test project and all three example tutorials still set them, so on any modern supported Django they were not using the tenant-aware storage backends at all:

| | `STORAGES['default']` | `STORAGES['staticfiles']` |
|---|---|---|
| before | `FileSystemStorage` | `StaticFilesStorage` |
| after | `TenantFileSystemStorage` | `TenantStaticFilesStorage` |

Nothing failed as a result, which is exactly the problem — the examples are what people copy, and they quietly configured single-tenant storage. That's what #1095 ran into after upgrading to 5.1.

`docs/files.rst` already showed `STORAGES` in its code block (keeping `DEFAULT_FILE_STORAGE` documented for Django < 4.2, which the package still supports), but the sentence above it still told the reader to change `DEFAULT_FILE_STORAGE`. Fixed.

Full suite: 120 tests, OK.

Refs #1095, #1173.