### PR TITLE
Add get_current_tenant (#1217), drop the dead --list option (#794), tidy is_public_schema (#339)

### DIFF
--- a/django_tenants/management/commands/migrate_schemas.py
+++ b/django_tenants/management/commands/migrate_schemas.py
@@ -41,8 +41,8 @@ class MigrateSchemasCommand(SyncCommon):
                             help='Detect if tables already exist and fake-apply initial migrations if so. Make sure '
                                  'that the current database schema matches your initial migration before using this '
                                  'flag. Django will only check for an existing table name.')
-        parser.add_argument('--list', '-l', action='store_true', dest='list', default=False,
-                            help='Show a list of all known migrations and which are applied')
+        # No --list: Django moved that functionality to `showmigrations` long ago, and nothing
+        # here ever read the flag, so it silently did nothing. See issue #794.
         parser.add_argument('--plan', action='store_true',
                             help='Shows a list of the migration actions that will be performed.',
         )

--- a/django_tenants/migration_executors/subproc.py
+++ b/django_tenants/migration_executors/subproc.py
@@ -44,8 +44,6 @@ def _options_to_argv(options: dict) -> list[str]:
         argv.append("--check")
     if options.get("plan"):
         argv.append("--plan")
-    if options.get("list"):
-        argv.append("--list")
     if not options.get("load_initial_data", True):
         argv.append("--no-initial-data")
     if options.get("database"):

--- a/django_tenants/templatetags/tenant.py
+++ b/django_tenants/templatetags/tenant.py
@@ -57,5 +57,7 @@ def colour_admin_apps():
 
 
 @register.simple_tag(takes_context=True)
-def is_public_schema(context, app):
+def is_public_schema(context, app=None):
+    # `app` is unused -- the answer depends only on the request's tenant -- but stays accepted
+    # so `{% is_public_schema app %}` in existing templates keeps working. See issue #339.
     return not hasattr(context.request, 'tenant') or context.request.tenant.schema_name == get_public_schema_name()

--- a/django_tenants/tests/test_utils.py
+++ b/django_tenants/tests/test_utils.py
@@ -6,7 +6,7 @@ from django_tenants.test.cases import TenantTestCase
 from django.core.management.commands.migrate import Command as MigrateCommand
 from django.test.utils import override_settings
 
-from django_tenants.utils import get_tenant
+from django_tenants.utils import get_current_tenant, get_tenant
 
 
 class CustomMigrateCommand(MigrateCommand):
@@ -53,3 +53,20 @@ class ConfigStringParsingTestCase(TenantTestCase):
         request = factory.get('/any/request/', HTTP_HOST=tenant_domain)
         tm.process_request(request)
         self.assertEqual(get_tenant(request).schema_name, 'test')
+
+    def test_get_current_tenant(self):
+        # The point of get_current_tenant (issue #1217) is that it takes no request, so it
+        # works from anywhere the connection is already set -- helpers, tasks, signals.
+        self.assertEqual(get_current_tenant().schema_name, self.tenant.schema_name)
+
+    def test_get_current_tenant_follows_schema_context(self):
+        with utils.schema_context(utils.get_public_schema_name()):
+            self.assertEqual(
+                get_current_tenant().schema_name, utils.get_public_schema_name()
+            )
+        # and is restored on the way out
+        self.assertEqual(get_current_tenant().schema_name, self.tenant.schema_name)
+
+    def test_get_current_tenant_returns_the_instance_under_tenant_context(self):
+        with utils.tenant_context(self.tenant):
+            self.assertEqual(get_current_tenant(), self.tenant)

--- a/django_tenants/utils.py
+++ b/django_tenants/utils.py
@@ -348,3 +348,17 @@ def get_tenant(request):
     if hasattr(request, 'tenant'):
         return request.tenant
     return None
+
+
+def get_current_tenant(database=None):
+    """Return the tenant the connection is currently set to, or None.
+
+    Unlike :func:`get_tenant` this takes no request, so it also works deep inside helper
+    functions, in Celery tasks, and under ``tenant_context()`` / ``schema_context()``.
+
+    ``tenant_context()`` sets the real tenant instance, so that is what comes back.
+    ``schema_context()`` only ever knows a schema name, so there a ``FakeTenant`` is
+    returned -- read its ``schema_name`` rather than expecting model fields, or use
+    ``tenant_context()`` when you need the model instance.
+    """
+    return getattr(connections[database or get_tenant_database_alias()], 'tenant', None)

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -127,9 +127,28 @@ You can also use `tenant_context` as a decorator.
     def my_func():
       # All commands in this function are ran under the schema from the `tenant` object
 
+.. function:: get_current_tenant
+
+Returns the tenant the connection is currently set to, or ``None``. Unlike ``get_tenant(request)``
+it takes no request, so it also works deep inside helper functions, in Celery tasks, and under
+``tenant_context()`` / ``schema_context()``.
+
+.. code-block:: python
+
+    from django_tenants.utils import get_current_tenant
+
+    def send_welcome_email(user):
+        tenant = get_current_tenant()   # no request needed
+        ...
+
+``tenant_context()`` sets the real tenant instance, so that is what comes back.
+``schema_context()`` only ever knows a schema name, so there a ``FakeTenant`` is returned --
+read its ``schema_name`` rather than expecting model fields, or use ``tenant_context()`` when
+you need the model instance.
+
 .. function:: @tenant_migration
 
-This decorator allows the flexibility to have data migrations (using ``migrations.RunPython``) execute specifically under a tenant or public schema for apps in both tenant/public INSTALLED_APPS. 
+This decorator allows the flexibility to have data migrations (using ``migrations.RunPython``) execute specifically under a tenant or public schema for apps in both tenant/public INSTALLED_APPS.
 It accepts boolean kwargs ``tenant_schema`` or ``public_schema`` - the default beign ``tenant_schema=True`` and ``public_schema=False``.
 
 .. code-block:: python


### PR DESCRIPTION
Three small items from the issue backlog.

## #1217 — `get_current_tenant()`

`get_tenant()` takes a request, so there was no way to ask *which tenant am I in* from a helper function, a Celery task, a signal handler, or inside `tenant_context()` / `schema_context()`. Adds:

```python
from django_tenants.utils import get_current_tenant

def send_welcome_email(user):
    tenant = get_current_tenant()   # no request needed
```

`tenant_context()` sets the real instance, so that's what comes back; `schema_context()` only knows a schema name, so a `FakeTenant` is returned there. That caveat is documented rather than left to be discovered. Three tests cover all three cases.

## #794 — remove the dead `--list` option

`migrate_schemas` advertised `--list`/`-l`, but nothing read `options['list']` — Django moved that to `showmigrations` long ago, so it silently did nothing. The reporter's words: *"it confused me for a LONG time"*.

Also removes the forwarding of it to child processes in the subprocess executor, which was passing a dead flag along.

**Behaviour note:** anyone passing `--list` today gets nothing; after this they get *unrecognized arguments*. That's the intent of the issue, but flagging it since it's a visible CLI change.

## #339 — `is_public_schema`'s unused `app` argument

The answer depends only on the request's tenant, so `app` was never read. Made **optional** rather than removed, so `{% is_public_schema app %}` in existing templates keeps working either way.

Full suite: 123 tests, OK.

Closes #1217. Closes #794. Closes #339.