### PR TITLE
Bump version to 3.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=61" ]
 
 [project]
 name = "django-tenants"
-version = "3.12.0"
+version = "3.13.0"
 description = "Tenant support for Django using PostgreSQL schemas."
 readme = "README.rst"
 license = "MIT"


### PR DESCRIPTION
Sets the version for the next release.

Minor rather than patch: `get_current_tenant()` is new public API, and `migrate_schemas` no longer accepts `--list` (#794) — a visible CLI change, even though the flag never did anything.

Contents since 3.12.0:
- #1239 quote role names in cloned DDL (#1189), plus the missing regression test for cloning inside `transaction.atomic()` (#1155, #694)
- #1240 `STORAGES` in the test project and all three example tutorials (#1095, #1173)
- #1241 `get_current_tenant()` (#1217), dead `--list` removed (#794), `is_public_schema` tidy (#339)