### PR TITLE
Fix the "How it works" links in the README and docs index (#894)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ http://customer.example.com. Any request incoming at
 and make the tenant available at the request. If no tenant is found, a
 404 error is raised. This also means you should have a tenant for your
 main domain, typically using the ``public`` schema. For more information
-please read the `setup`_ section.
+please read the `installation`_ section.
 
 What can this app do?
 ---------------------
@@ -288,9 +288,9 @@ If this project helped you reduce development time, you can give me cake :)
 .. _PostgreSQL schemas: http://www.postgresql.org/docs/9.1/static/ddl-schemas.html
 .. _PostgreSQL’s official documentation on schemas: http://www.postgresql.org/docs/9.1/static/ddl-schemas.html
 .. _Multi-Tenant Data Architecture: https://web.archive.org/web/20160311212239/https://msdn.microsoft.com/en-us/library/aa479086.aspx
-.. _setup: https://django-tenants.readthedocs.org/en/latest/install.html
-.. _examples: https://django-tenants.readthedocs.org/en/latest/examples.html
-.. _django-tenants.readthedocs.org: https://django-tenants.readthedocs.org/en/latest/
+.. _installation: https://django-tenants.readthedocs.io/en/latest/install.html
+.. _examples: https://django-tenants.readthedocs.io/en/latest/examples.html
+.. _django-tenants.readthedocs.org: https://django-tenants.readthedocs.io/en/latest/
 .. _django-tenant-schemas: http://github.com/bernardopires/django-tenant-schemas
 .. _django-schemata: https://github.com/tuttle/django-schemata
 .. _docker-compose: https://docs.docker.com/engine/reference/run/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Each solution has it's up and down sides, for a more in-depth discussion, see Mi
 
 How it works
 ------------
-Tenants are identified via their host name (i.e tenant.domain.com). This information is stored on a table on the ``public`` schema. Whenever a request is made, the host name is used to match a tenant in the database. If there's a match, the search path is updated to use this tenant's schema. So from now on all queries will take place at the tenant's schema. For example, suppose you have a tenant ``customer`` at http://customer.example.com. Any request incoming at ``customer.example.com`` will automatically use ``customer``'s schema and make the tenant available at the request. If no tenant is found, a 404 error is raised. This also means you should have a tenant for your main domain, typically using the ``public`` schema. For more information please read the :doc:`use <use>` section.
+Tenants are identified via their host name (i.e tenant.domain.com). This information is stored on a table on the ``public`` schema. Whenever a request is made, the host name is used to match a tenant in the database. If there's a match, the search path is updated to use this tenant's schema. So from now on all queries will take place at the tenant's schema. For example, suppose you have a tenant ``customer`` at http://customer.example.com. Any request incoming at ``customer.example.com`` will automatically use ``customer``'s schema and make the tenant available at the request. If no tenant is found, a 404 error is raised. This also means you should have a tenant for your main domain, typically using the ``public`` schema. For more information please read the :doc:`installation <install>` section.
 
 .. important::
 


### PR DESCRIPTION
Reopened #894 — my earlier close was premature. I checked `docs/index.rst` and missed that `README.rst` has its own copy of the same paragraph, with its own link. Thanks @egor83 for coming back on it.

Taking the three points in turn:

**3. The README still says "please read the [setup] section".** Correct, and it was wrong. `.. _setup:` pointed at `install.html`, whose page is titled **Installation** — so the link text named a section that does not exist. Renamed the target to `installation`_ so the text and the destination agree.

**Bonus:** `docs/index.rst` pointed the reader at the **use** page. The original broken link was an internal `#setup` anchor, and the README means installation, so both now point to the same place: `:doc:`installation <install>``. Verified by building the docs — the emitted markup is `href="install.html"` with the text "installation", and the Sphinx warning count is unchanged from master (7 on both, all pre-existing).

Also moved the three `readthedocs.org` URLs to the canonical `readthedocs.io`.

**1 and 2 — the `.rst` looking odd and the link landing on `#id1` when read on GitHub.** This one I cannot fix, and I would rather say so than pretend otherwise. `:doc:` is a Sphinx role; GitHub's `.rst` viewer does not implement it, so it renders the role literally and invents an `#id1` anchor. Any Sphinx cross-reference in `docs/*.rst` will look wrong when browsed on GitHub — the rendered docs at https://django-tenants.readthedocs.io are the intended reading surface.

The alternative would be hard-coding `https://django-tenants.readthedocs.io/en/latest/install.html` into `docs/index.rst`, but that pins every reader to `latest` regardless of which version they are reading, and loses Sphinx's build-time link checking — a worse trade for the docs themselves.

What does matter is that the **README** is the page GitHub renders as the project homepage, and that now carries a plain absolute link that resolves correctly.

Closes #894.