### PR TITLE
Add tenant-isolation tests for QuerySet.iterator() (server-side cursors)

### DIFF
--- a/django_tenants/tests/test_server_side_cursors.py
+++ b/django_tenants/tests/test_server_side_cursors.py
@@ -1,0 +1,197 @@
+"""
+Tests for ``QuerySet.iterator()`` (server-side cursors) under tenancy.
+
+``DatabaseWrapper._cursor()`` has a dedicated branch for named cursors: a named
+cursor can only execute one statement, so ``SET search_path`` has to be issued
+on a *separate* cursor before the query runs. That branch had no test coverage,
+which matters more than it looks -- a named cursor resolves its table names when
+Postgres runs ``DECLARE``, so if the search_path were not established first an
+``.iterator()`` would silently read from the wrong schema.
+
+The tests below assert against ``pg_cursors``, Postgres' own view of the cursors
+open in the current session. That is deliberate: an isolation test that only
+checks the returned rows would still pass if Django quietly stopped using a
+server-side cursor, which is exactly the regression worth catching.
+"""
+
+from unittest import mock
+
+from django.db import connection
+from django.test.utils import override_settings
+
+from dts_test_app.models import DummyModel
+
+from django_tenants.tests.testcases import BaseTestCase
+from django_tenants.utils import get_tenant_domain_model, get_tenant_model, tenant_context
+
+DJANGO_CURSOR_PREFIX = '_django_curs_'
+
+
+class ServerSideCursorTenantTest(BaseTestCase):
+    """
+    ``.iterator()`` must stay inside the tenant whose schema was active when the
+    cursor was declared.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sync_shared()
+
+    def setUp(self):
+        super().setUp()
+
+        self.created = []
+
+        self.tenant1 = get_tenant_model()(schema_name='cursor_tenant_1')
+        self.tenant1.save()
+        self.domain1 = get_tenant_domain_model()(tenant=self.tenant1, domain='cursor-one.test.com')
+        self.domain1.save()
+
+        connection.set_schema_to_public()
+
+        self.tenant2 = get_tenant_model()(schema_name='cursor_tenant_2')
+        self.tenant2.save()
+        self.domain2 = get_tenant_domain_model()(tenant=self.tenant2, domain='cursor-two.test.com')
+        self.domain2.save()
+
+        self.created = [self.domain2, self.domain1, self.tenant2, self.tenant1]
+
+        # Distinguishable rows, and more of them than the chunk_size used below so
+        # that the cursor is still open part-way through iteration.
+        with tenant_context(self.tenant1):
+            for name in ('t1-a', 't1-b', 't1-c'):
+                DummyModel(name=name).save()
+
+        with tenant_context(self.tenant2):
+            for name in ('t2-a', 't2-b'):
+                DummyModel(name=name).save()
+
+    def tearDown(self):
+        from django_tenants.models import TenantMixin
+
+        connection.set_schema_to_public()
+
+        for c in self.created:
+            if isinstance(c, TenantMixin):
+                c.delete(force_drop=True)
+            else:
+                c.delete()
+
+        super().tearDown()
+
+    @staticmethod
+    def open_server_side_cursor_names():
+        """
+        Names of the server-side cursors Postgres currently holds for this session.
+        """
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT name FROM pg_cursors')
+            return [row[0] for row in cursor.fetchall()]
+
+    def django_cursor_is_open(self):
+        return any(name.startswith(DJANGO_CURSOR_PREFIX)
+                   for name in self.open_server_side_cursor_names())
+
+    def test_iterator_really_uses_a_server_side_cursor(self):
+        """
+        Guard test. If Django stops opening a server-side cursor here, the
+        isolation tests below would pass without ever exercising the named-cursor
+        branch of ``_cursor()`` -- so assert the cursor genuinely exists in
+        Postgres before trusting anything else in this module.
+        """
+        connection.set_tenant(self.tenant1)
+
+        iterator = DummyModel.objects.iterator(chunk_size=1)
+        try:
+            next(iterator)
+            self.assertTrue(
+                self.django_cursor_is_open(),
+                'expected an open server-side cursor in pg_cursors; got %r'
+                % (self.open_server_side_cursor_names(),),
+            )
+        finally:
+            iterator.close()
+
+    def test_iterator_is_scoped_to_the_current_tenant(self):
+        """
+        The whole point: ``SET search_path`` must have run before ``DECLARE``, so
+        each tenant's iterator sees only its own rows.
+        """
+        with tenant_context(self.tenant1):
+            self.assertEqual(
+                ['t1-a', 't1-b', 't1-c'],
+                sorted(obj.name for obj in DummyModel.objects.iterator(chunk_size=1)),
+            )
+
+        with tenant_context(self.tenant2):
+            self.assertEqual(
+                ['t2-a', 't2-b'],
+                sorted(obj.name for obj in DummyModel.objects.iterator(chunk_size=1)),
+            )
+
+    def test_iterator_keeps_its_schema_across_a_tenant_switch(self):
+        """
+        A cursor is bound to the schema it was declared against, so switching the
+        connection to another tenant part-way through iteration must not retarget
+        an already-open iterator.
+        """
+        connection.set_tenant(self.tenant1)
+
+        iterator = DummyModel.objects.iterator(chunk_size=1)
+        try:
+            names = [next(iterator).name]
+
+            with tenant_context(self.tenant2):
+                # Still tenant1's cursor: tenant2's rows must not appear.
+                names.extend(obj.name for obj in iterator)
+        finally:
+            iterator.close()
+
+        self.assertEqual(['t1-a', 't1-b', 't1-c'], sorted(names))
+
+    @override_settings(TENANT_LIMIT_SET_CALLS=True)
+    def test_iterator_is_tenant_scoped_with_limited_set_calls(self):
+        """
+        ``TENANT_LIMIT_SET_CALLS`` suppresses redundant ``SET search_path`` calls
+        by caching ``search_path_set_schemas``. Switching tenant clears that cache
+        (``set_tenant``), so iterators must still be correctly scoped.
+        """
+        with tenant_context(self.tenant1):
+            self.assertEqual(
+                ['t1-a', 't1-b', 't1-c'],
+                sorted(obj.name for obj in DummyModel.objects.iterator(chunk_size=1)),
+            )
+
+        with tenant_context(self.tenant2):
+            self.assertEqual(
+                ['t2-a', 't2-b'],
+                sorted(obj.name for obj in DummyModel.objects.iterator(chunk_size=1)),
+            )
+
+    def test_iterator_is_tenant_scoped_without_server_side_cursors(self):
+        """
+        ``DISABLE_SERVER_SIDE_CURSORS`` is required when running behind a pooler in
+        transaction pooling mode. It makes ``.iterator()`` fetch client-side, which
+        costs memory but must not change which schema the rows come from.
+        """
+        with mock.patch.dict(connection.settings_dict, {'DISABLE_SERVER_SIDE_CURSORS': True}):
+            with tenant_context(self.tenant1):
+                iterator = DummyModel.objects.iterator(chunk_size=1)
+                next(iterator)
+                self.assertFalse(
+                    self.django_cursor_is_open(),
+                    'no server-side cursor should be opened when they are disabled',
+                )
+                iterator.close()
+
+                self.assertEqual(
+                    ['t1-a', 't1-b', 't1-c'],
+                    sorted(obj.name for obj in DummyModel.objects.iterator(chunk_size=1)),
+                )
+
+            with tenant_context(self.tenant2):
+                self.assertEqual(
+                    ['t2-a', 't2-b'],
+                    sorted(obj.name for obj in DummyModel.objects.iterator(chunk_size=1)),
+                )


### PR DESCRIPTION
## Why

`DatabaseWrapper._cursor()` has a dedicated branch for named cursors. A named cursor can only execute one statement, so `SET search_path` cannot be issued on it — it has to run on a separate cursor first:

https://github.com/django-tenants/django-tenants/blob/master/django_tenants/postgresql_backend/base.py#L158-L163

```python
if name or is_psycopg3:
    # Named cursor can only be used once, psycopg3 and Django 4 have recursion issue
    cursor_for_search_path = self.connection.cursor()
else:
    # Reuse
    cursor_for_search_path = cursor
```

That branch had **no test coverage**, and it is the one place in the backend where a mistake reads as working code. A named cursor resolves its table names when Postgres runs `DECLARE`. If `SET search_path` had not run by then, the cursor is declared against whatever schema the session happened to be on — so `.iterator()` returns **another tenant's rows**, silently, rather than raising.

The branch also has history: 340f137 ("avoid recursion errors on psycopg3 & Django 4") was a fix to keep it working. It is maintained functionality with no regression test.

## What this adds

`django_tenants/tests/test_server_side_cursors.py` — five tests, two tenants holding distinguishable rows.

| Test | Asserts |
|---|---|
| `test_iterator_really_uses_a_server_side_cursor` | a `_django_curs_` cursor is genuinely open in `pg_cursors` |
| `test_iterator_is_scoped_to_the_current_tenant` | each tenant's iterator sees only its own rows |
| `test_iterator_keeps_its_schema_across_a_tenant_switch` | an open cursor is not retargeted by `tenant_context` mid-iteration |
| `test_iterator_is_tenant_scoped_with_limited_set_calls` | still correct under `TENANT_LIMIT_SET_CALLS=True` |
| `test_iterator_is_tenant_scoped_without_server_side_cursors` | the `DISABLE_SERVER_SIDE_CURSORS` path is also tenant-correct |

### The design decision worth reviewing

The tests assert against **`pg_cursors`** — Postgres' own view of the cursors open in the current session — rather than only checking the rows that come back:

```python
with connection.cursor() as cursor:
    cursor.execute('SELECT name FROM pg_cursors')
```

That is deliberate. An isolation test that only checks returned rows would keep passing if Django ever stopped opening a server-side cursor here, because a client-side fetch returns the same rows. The named-cursor branch would then be silently untested again while the suite stayed green. `test_iterator_really_uses_a_server_side_cursor` exists purely to fail in that case, and it guards the other four.

## Verification

Both mutations were run to confirm the tests can fail, not just pass.

**Mutation A** — make `_cursor()` skip `SET search_path` for named cursors, i.e. the bug the untested branch could hide:

```
FAIL: test_iterator_is_scoped_to_the_current_tenant
AssertionError: Lists differ: ['t1-a', 't1-b', 't1-c'] != ['t2-a', 't2-b']
FAIL: test_iterator_is_tenant_scoped_with_limited_set_calls
FAIL: test_iterator_keeps_its_schema_across_a_tenant_switch
FAILED (failures=3)
```

Tenant 2's rows returned where tenant 1's were asserted — the leak, reproduced.

**Mutation B** — `DISABLE_SERVER_SIDE_CURSORS` on globally, simulating a silent fallback to client-side fetching:

```
FAIL: test_iterator_really_uses_a_server_side_cursor
AssertionError: False is not true : expected an open server-side cursor in pg_cursors; got []
FAILED (failures=1)
```

The guard doing its job. Without it, the three isolation tests above would have stayed green while never touching the named-cursor branch.

## Test matrix

Run against PostgreSQL 17 in a throwaway container, both drivers:

| | Result |
|---|---|
| Django 6.0.8 / psycopg 3.2.13 (`is_psycopg3=True`) | `Ran 5 tests — OK` |
| Django 5.2.9 / psycopg2 2.9.12 (`is_psycopg3=False`) | `Ran 5 tests — OK` |

Both drivers matter here because `base.py:158` branches on `is_psycopg3`. With a named cursor the condition is true either way, so both take the separate-cursor path — but that is worth having pinned rather than assumed.

## Pre-existing failures, not introduced here

`test_switching_search_path` and `test_switching_search_path_limited_calls` fail on **psycopg2 only**, with `6 != 3 : 6 queries executed, 3 expected`. Confirmed pre-existing by re-running with this file removed, and raised separately as #1244.

(An earlier revision of this description also listed `test_deprecated_module_raises_warning` as failing. That was an artefact of invoking `manage.py test` directly: it passes under `PYTHONWARNINGS=d`, which `run_tests.sh` sets. Not a real failure.)

## Scope

Tests only — no behaviour change. It documents and pins existing behaviour rather than altering it.

Worth noting what this establishes, since it comes up regularly: `DISABLE_SERVER_SIDE_CURSORS` is **not** a django-tenants requirement. It is never mentioned in the docs, never set by the library, and `.iterator()` is tenant-safe without it. The last test in the file also pins the disabled path, so both configurations are covered and the reason for choosing one over the other stays a pooler question rather than a tenancy one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
