### PR TITLE
Add Django 6.1 support

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        django-version: ["==4.2.*", "==5.2.*", "==6.0.*"]
+        django-version: ["==4.2.*", "==5.2.*", "==6.0.*", "==6.1.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
         exclude:
@@ -59,6 +59,11 @@ jobs:
           - django-version: "==6.0.*"
             python-version: "3.10"
           - django-version: "==6.0.*"
+            python-version: "3.11"
+          # Django 6.1 requires Python 3.12+
+          - django-version: "==6.1.*"
+            python-version: "3.10"
+          - django-version: "==6.1.*"
             python-version: "3.11"
 
     steps:
@@ -71,7 +76,10 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        pip install Django${{ matrix.django-version }}
+        # --pre so a not-yet-final Django series resolves to its release candidate.
+        # Whether pip falls back to a pre-release on its own is pip-version dependent,
+        # and an ==X.Y.* specifier still keeps other series on their final releases.
+        pip install --pre Django${{ matrix.django-version }}
         pip install -e ".[dev]"
 
     - name: Create database

--- a/django_tenants/postgresql_backend/introspection.py
+++ b/django_tenants/postgresql_backend/introspection.py
@@ -1,3 +1,9 @@
+# Import the backend's base module before its introspection module. On Django 6.1
+# `django.db.backends.postgresql.introspection` imports `psycopg_version` from
+# `...postgresql.base`, which in turn imports `...postgresql.introspection` -- so
+# importing introspection first leaves base half-initialised and the cycle raises
+# ImportError. Django itself never hits this because base is always imported first.
+import django.db.backends.postgresql.base  # noqa: F401
 from django.db.backends.postgresql.introspection import DatabaseIntrospection
 
 

--- a/django_tenants/tests/staticfiles/test_finders.py
+++ b/django_tenants/tests/staticfiles/test_finders.py
@@ -1,5 +1,6 @@
 import os
 
+import django
 from django.conf import settings
 from django.db import connection
 
@@ -128,7 +129,11 @@ class TenantFileSystemFinderTestCase(TenantTestCase):
         self.assertEqual(os.path.normcase(found), os.path.normcase(self.test_file_path))
 
     def test_find_all(self):
-        found = self.finder.find(self.source_path, all=True)
+        # Django 5.2 renamed this keyword from `all` to `find_all`, keeping the old
+        # spelling working via **kwargs, and 6.1 dropped **kwargs -- so `all=True`
+        # is a TypeError there. Pick whichever the running version accepts.
+        kwarg = 'find_all' if django.VERSION >= (5, 2) else 'all'
+        found = self.finder.find(self.source_path, **{kwarg: True})
         found = [os.path.normcase(f) for f in found]
 
         self.assertEqual(found, [os.path.normcase(self.test_file_path)])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
   "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
@@ -29,7 +30,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "django>=2.1,<6.1",
+  "django>=2.1,<6.2",
 ]
 
 optional-dependencies.dev = [


### PR DESCRIPTION
Closes #1246.

Django 6.1rc1 is on PyPI, so 6.1 stable is imminent. django-tenants currently **fails to import at all** on it — this is not a test-only problem, `manage.py` cannot start.

## 1. Circular import — the actual blocker

```
ImportError: cannot import name 'DatabaseIntrospection' from partially initialized
module 'django.db.backends.postgresql.introspection' (most likely due to a circular import)
```

Django 6.1 added `from django.db.backends.postgresql.base import psycopg_version` to its PostgreSQL introspection module. `base` already imports `introspection`, so the two now form a cycle:

```
django_tenants/postgresql_backend/introspection.py:1
  → django/db/backends/postgresql/introspection.py:6   (imports psycopg_version from base)
    → django/db/backends/postgresql/base.py:81         (imports .introspection — half-initialised)
```

Django itself never hits this, because in normal use `base` is always imported first and primes the module. It only breaks for a third party that imports `introspection` first — which we did, on line 1.

**Fix:** import the backend's base module first. Pure ordering; it is an import that already happens, just earlier. No behaviour change on any Django version.

## 2. `find(all=True)` removed in 6.1

```
File "django_tenants/tests/staticfiles/test_finders.py", line 131, in test_find_all
    found = self.finder.find(self.source_path, all=True)
TypeError: FileSystemFinder.find() got an unexpected keyword argument 'all'
```

Worth being precise, because the obvious guess is wrong — there is **no `find_all()` method** on any of these versions. The *keyword* was renamed:

| Django | `FileSystemFinder.find` signature |
|---|---|
| 4.2 | `find(self, path, all=False)` |
| 5.2 | `find(self, path, find_all=False, **kwargs)` — old `all=` still tolerated |
| 6.0 | `find(self, path, find_all=False, **kwargs)` |
| 6.1 | `find(self, path, find_all=False)` — `**kwargs` gone, so `all=` raises |

`TenantFileSystemFinder` does not override `find()`, so this is **test-only** — the finder itself is unaffected, and `test_finders.py:131` was the only use of the old spelling in the codebase. Since 4.2 is still supported, the spelling is picked from `django.VERSION` rather than swapped outright.

## 3 & 4. Packaging and CI

- `pyproject.toml`: `django>=2.1,<6.2`, plus `"Framework :: Django :: 6.1"`.
- `.github/workflows/code.yml`: `"==6.1.*"` added to the matrix, excluding Python 3.10 and 3.11 (6.1 requires `>=3.12`).

### One non-obvious change worth reviewing

The Django install line gains `--pre`:

```yaml
pip install --pre Django${{ matrix.django-version }}
```

I originally concluded this was unnecessary, because pip resolved `Django==6.1.*` to `6.1rc1` on its own. That turned out to be **pip-version dependent**:

```
pip 26.2.1 →  Would install Django-6.1rc1
pip 25.0.1 →  ERROR: No matching distribution found for Django==6.1.*
```

`setup-python` bundles whatever pip ships with each interpreter, so without `--pre` the 6.1 leg would fail on some runners until 6.1 final ships — and with `fail-fast: true` that reds the whole job. `--pre` makes it deterministic, and an `==X.Y.*` specifier still keeps every other series on its final release (verified: `--pre Django==6.0.*` → `6.0.8`, not `6.0rc1`).

Once 6.1 final ships the flag becomes a no-op for this matrix, but it will save the same trouble for 6.2.

## Verification

`./run_tests.sh` — the full CI entry point, so both executors *and* the `create_tenant` / `clone_tenant` integration steps, not just `manage.py test`. Python 3.12 / PostgreSQL 17 / psycopg3, database dropped and recreated between runs:

```
Django 4.2.30    exit 0 | executors OK 2/2 | unit FAIL/ERROR 0 | clone_tenant 1
Django 5.2.17    exit 0 | executors OK 2/2 | unit FAIL/ERROR 0 | clone_tenant 1
Django 6.0.8     exit 0 | executors OK 2/2 | unit FAIL/ERROR 0 | clone_tenant 1
Django 6.1rc1    exit 0 | executors OK 2/2 | unit FAIL/ERROR 0 | clone_tenant 1
```

Green on all four, including the `clone_tenant` PL/pgSQL path — which matters here, since the import fix touches the backend module graph that cloning also loads.

### Honest limits on that evidence

- **6.1rc1, not 6.1 final.** Release candidates are usually identical to final, but not guaranteed.
- **Python 3.12 and PostgreSQL 17 only.** The matrix in this PR covers 3.12/3.13 and Postgres 14–17; CI will exercise what I did not.
- **psycopg3 only.** On psycopg2 `run_tests.sh` fails for reasons tracked in #1244 (`assertNumQueries` counting `SET search_path`), which is independent of 6.1 and unaffected by this PR.

So: no known blockers beyond the two fixed here, rather than a full matrix pass. CI on this PR is the real test.

## Scope

Independent of #1245 (cursor tests) and of the driver-agnostic work for #1244 — no overlapping files, mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
