### PR TITLE
Drop Django 4.2 support (EOL 7 April 2026)

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -50,12 +50,10 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        django-version: ["==4.2.*", "==5.2.*", "==6.0.*", "==6.1.*"]
+        django-version: ["==5.2.*", "==6.0.*", "==6.1.*"]
         # always use latest Postgres b/c the point here is to test Django compatibility
         postgres-version: [latest]
         exclude:
-          - django-version: "==4.2.*"
-            python-version: "3.13"
           - django-version: "==6.0.*"
             python-version: "3.10"
           - django-version: "==6.0.*"

--- a/django_tenants/postgresql_backend/base.py
+++ b/django_tenants/postgresql_backend/base.py
@@ -11,10 +11,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 import django.db.utils
 
-try:
-     from django.db.backends.postgresql.psycopg_any import is_psycopg3
-except ImportError:
-    is_psycopg3 = False
+from django.db.backends.postgresql.psycopg_any import is_psycopg3
 
 if is_psycopg3:
     import psycopg

--- a/django_tenants/tests/staticfiles/test_finders.py
+++ b/django_tenants/tests/staticfiles/test_finders.py
@@ -1,6 +1,5 @@
 import os
 
-import django
 from django.conf import settings
 from django.db import connection
 
@@ -129,11 +128,9 @@ class TenantFileSystemFinderTestCase(TenantTestCase):
         self.assertEqual(os.path.normcase(found), os.path.normcase(self.test_file_path))
 
     def test_find_all(self):
-        # Django 5.2 renamed this keyword from `all` to `find_all`, keeping the old
-        # spelling working via **kwargs, and 6.1 dropped **kwargs -- so `all=True`
-        # is a TypeError there. Pick whichever the running version accepts.
-        kwarg = 'find_all' if django.VERSION >= (5, 2) else 'all'
-        found = self.finder.find(self.source_path, **{kwarg: True})
+        # `find_all` is the spelling from Django 5.2 onwards; the older `all`
+        # keyword was removed in 6.1.
+        found = self.finder.find(self.source_path, find_all=True)
         found = [os.path.normcase(f) for f in found]
 
         self.assertEqual(found, [os.path.normcase(self.test_file_path)])

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -6,7 +6,6 @@ from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.db import connection, transaction
 from django.test.utils import override_settings
-from django.utils.version import get_main_version, get_version_tuple
 
 from django_tenants.clone import CloneSchema
 from django_tenants.signals import schema_migrated, schema_migrate_message, schema_pre_migration
@@ -384,15 +383,10 @@ class TestSyncTenantsWithAuth(BaseSyncTest):
                    'django.contrib.sessions', )  # 1 table
     TENANT_APPS = ('django.contrib.sessions', )  # 1 table
 
-    if get_version_tuple(get_main_version()) < (5, 2):
-        def _pre_setup(self):
-            self.sync_shared()
-            super()._pre_setup()
-    else:
-        @classmethod
-        def _pre_setup(cls):
-            cls.sync_shared()
-            super()._pre_setup()
+    @classmethod
+    def _pre_setup(cls):
+        cls.sync_shared()
+        super()._pre_setup()
 
     def test_tenant_apps_and_shared_apps_can_have_the_same_apps(self):
         """

--- a/docs/files.rst
+++ b/docs/files.rst
@@ -134,9 +134,6 @@ The above behaviour can be changed for multi-tenant setups so that each tenant w
         },
     }
 
-    # OR, in the unlikely case you're using django < 4.2
-    DEFAULT_FILE_STORAGE = "django_tenants.files.storage.TenantFileSystemStorage"
-
     MULTITENANT_RELATIVE_MEDIA_ROOT = ""  # (default: create sub-directory for each tenant)
 
 The path specified in ``MULTITENANT_RELATIVE_MEDIA_ROOT`` tells ``TenantFileSystemStorage`` where in ``MEDIA_ROOT`` the tenant's files should be saved. The default behaviour is to just create a sub-directory for each tenant in ``MEDIA_ROOT``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
   "Framework :: Django",
-  "Framework :: Django :: 4.2",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
   "Framework :: Django :: 6.1",
@@ -30,7 +29,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "django>=2.1,<6.2",
+  "django>=5.2,<6.2",
 ]
 
 optional-dependencies.dev = [


### PR DESCRIPTION
> **Stacked on #1247** — base is `feat/django-6.1-support`, so this diff shows only the 4.2 changes. GitHub will retarget it to `master` automatically once #1247 merges. Merge #1247 first.

## Why now

Django 4.2 LTS reached **end of extended support on 7 April 2026**. Upstream now lists it under "Unsupported previous releases", which "no longer receive security updates or bug fixes" — so nothing in 4.2 will ever be fixed again.

We were still declaring support for it (`django>=2.1`), testing it across three Python versions on every PR, and carrying version shims for it.

## What changes

- **`pyproject.toml`**: `django>=5.2,<6.2`, and the 4.2 classifier goes. `requires-python` stays `>=3.10` — 5.2 still supports it, so no Python floor change.
- **CI**: the `==4.2.*` matrix entry and its Python 3.13 exclude are removed. Three fewer jobs per run.

## The part that makes this worth doing

Dropping 4.2 turns four pieces of compatibility code into dead code, and they all go:

**1. `postgresql_backend/base.py` — the psycopg driver detection**

```diff
-try:
-     from django.db.backends.postgresql.psycopg_any import is_psycopg3
-except ImportError:
-    is_psycopg3 = False
+from django.db.backends.postgresql.psycopg_any import is_psycopg3
```

`psycopg_any` has existed since 4.2, so the `ImportError` branch was already unreachable for every supported version.

**2. `tests/test_tenants.py` — the `_pre_setup` fork**

```diff
-    if get_version_tuple(get_main_version()) < (5, 2):
-        def _pre_setup(self):
-            self.sync_shared()
-            super()._pre_setup()
-    else:
-        @classmethod
-        def _pre_setup(cls):
-            cls.sync_shared()
-            super()._pre_setup()
+    @classmethod
+    def _pre_setup(cls):
+        cls.sync_shared()
+        super()._pre_setup()
```

Plus the now-unused `get_main_version` / `get_version_tuple` imports.

**3. `tests/staticfiles/test_finders.py` — the `find_all` keyword choice**

#1247 had to pick the keyword at runtime, because 4.2 wanted `all=True` and 6.1 removed it. With 5.2 as the floor, `find_all` is universal:

```diff
-        kwarg = 'find_all' if django.VERSION >= (5, 2) else 'all'
-        found = self.finder.find(self.source_path, **{kwarg: True})
+        found = self.finder.find(self.source_path, find_all=True)
```

**4. `docs/files.rst`** — the `DEFAULT_FILE_STORAGE` fallback documented for "django < 4.2".

## Verification

`./run_tests.sh` — both executors plus the `create_tenant` / `clone_tenant` integration steps — on Python 3.12 / PostgreSQL 17 / psycopg3, fresh database per run:

```
Django 5.2.17    exit 0 | Ran 130 tests | executors OK 2/2 | FAIL 0 | clone_tenant 1
Django 6.0.8     exit 0 | Ran 130 tests | executors OK 2/2 | FAIL 0 | clone_tenant 1
Django 6.1rc1    exit 0 | Ran 130 tests | executors OK 2/2 | FAIL 0 | clone_tenant 1
```

The 130 includes the five `test_server_side_cursors` tests from #1245, so the backend import change is exercised against the tenant-isolation suite as well.

The new floor is **enforced, not merely declared** — resolving against 4.2 now fails rather than quietly working:

```
ERROR: Cannot install Django==4.2.30 and django-tenants==3.13.0 because these
package versions have conflicting dependencies.
```

## Knock-on effect worth noting

This also unblocks the driver-agnostic work for #1244. The one failure in that prototype was `test_switching_search_path` returning `9 != 6` on **Django 4.2 + psycopg3 only** — caused by Django's own `compose_sql`/`mogrify` opening a second cursor per statement, which each triggered a `SET search_path`. Since 4.2 gets no further releases, that was never going to be fixed upstream, and it was the only reason that prototype needed a version-conditional assertion. With 4.2 gone it needs none.

## Release note

This is a breaking change for anyone still on Django 4.2 — worth a minor or major version bump depending on your semver policy, and a line in the release notes. The upgrade path is "move to Django 5.2 LTS", which is supported until April 2028.
