### PR TITLE
Bump version to 3.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=61" ]
 
 [project]
 name = "django-tenants"
-version = "3.13.0"
+version = "3.14.0"
 description = "Tenant support for Django using PostgreSQL schemas."
 readme = "README.rst"
 license = "MIT"


### PR DESCRIPTION
Version bump for the 3.14.0 release. Draft release notes are prepared and will be attached as a draft GitHub release — publishing that release triggers the PyPI upload via trusted publishing, so it stays a draft until you're ready.

Minor rather than major despite dropping Django 4.2. That matches precedent: `0f559a3` removed Django 3.1 and 4.0, `f3f72d3` reworked supported versions, and 3.13.0 shipped its own `## Breaking` section — all without a major bump.

Contents since v3.13.0:

| PR | |
|---|---|
| #1243 | Docs — "How it works" links in README and docs index |
| #1245 | Tests — tenant-isolation coverage for `QuerySet.iterator()` |
| #1247 | New — Django 6.1 support (closes #1246) |
| #1248 | Breaking — Django 4.2 dropped, EOL 7 April 2026 |
| #1249 | Fix — driver-agnostic `search_path`, psycopg2 now tested (fixes #1244) |

The release workflow checks the tag against `pyproject.toml`, so this needs to merge before the release is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)