### PR TITLE
Prevent two tenants whose schema names differ only in case (#846)

### DIFF
--- a/django_tenants/clone.py
+++ b/django_tenants/clone.py
@@ -4617,7 +4617,9 @@ class CloneSchema:
         # TransactionManagementError when the caller is inside an atomic block (#1155, #694).
         self._create_clone_schema_function()
 
-        if schema_exists(new_schema_name):
+        # Ignore case: a clone target differing only in case from an existing
+        # schema would leave two tenants fighting over one schema. #846
+        if schema_exists(new_schema_name, case_sensitive=False):
             raise ValidationError("New schema name already exists")
 
         sql = "SELECT clone_schema(%(base_schema)s, %(new_schema)s, %(clone_mode)s)"

--- a/django_tenants/models.py
+++ b/django_tenants/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.db import models, connections, transaction
 from django.urls import reverse
@@ -99,6 +100,29 @@ class TenantMixin(models.Model):
         connection = connections[get_tenant_database_alias()]
         connection.set_schema_to_public()
 
+    def _check_schema_name_is_unique(self):
+        """
+        Rejects a schema name that only differs in case from an existing tenant's.
+
+        The unique constraint on schema_name is case sensitive, as are PostgreSQL
+        schema names themselves, but django-tenants treats names that differ only
+        in case as the same tenant -- see schema_exists() and schema_rename().
+        Without this check, creating a tenant 'C2' alongside an existing 'c2' is
+        accepted by the database and leaves two tenants fighting over one schema.
+        #846
+
+        Only called when adding a tenant, which is the only way to introduce a
+        collision -- renames go through schema_rename(), which checks for itself.
+        Saves on tenants that already collide are left alone so that upgrading
+        doesn't lock anyone out of their own data. Since the row does not exist
+        yet there is nothing to exclude from the query.
+        """
+        if self.__class__.objects.filter(schema_name__iexact=self.schema_name).exists():
+            raise ValidationError(
+                "A tenant with the schema name '%s' already exists. Schema names are "
+                "compared ignoring case." % self.schema_name
+            )
+
     def save(self, verbosity=1, *args, **kwargs):
         connection = connections[get_tenant_database_alias()]
         is_new = self._state.adding
@@ -110,6 +134,9 @@ class TenantMixin(models.Model):
             raise Exception("Can't update tenant outside it's own schema or "
                             "the public schema. Current schema is %s."
                             % connection.schema_name)
+
+        if is_new:
+            self._check_schema_name_is_unique()
 
         super().save(*args, **kwargs)
 

--- a/django_tenants/tests/test_tenants.py
+++ b/django_tenants/tests/test_tenants.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.db import connection, transaction
 from django.test.utils import override_settings
@@ -603,6 +604,70 @@ class TenantRenameSchemaTest(BaseTestCase):
         schema_rename(tenant=Client.objects.filter(pk=tenant.pk).first(), new_schema_name='4321_new_name')
         self.assertFalse(schema_exists('1234_test'))
         self.assertTrue(schema_exists('4321_new_name'))
+
+
+class TenantSchemaNameCaseTest(BaseTestCase):
+    """
+    Schema names that differ only in case must not produce two tenants. #846
+    """
+
+    def test_tenant_differing_only_in_case_is_rejected(self):
+        Client = get_tenant_model()
+        tenant = Client(schema_name='case_test')
+        tenant.save()
+
+        with self.assertRaises(ValidationError):
+            Client(schema_name='CASE_TEST').save()
+
+        self.assertEqual(Client.objects.filter(schema_name__iexact='case_test').count(), 1)
+
+    def test_saving_an_existing_tenant_does_not_collide_with_itself(self):
+        Client = get_tenant_model()
+        tenant = Client(schema_name='case_test')
+        tenant.save()
+
+        # The check runs on insert only, so re-saving must not see the tenant's
+        # own row as a duplicate of itself.
+        tenant.save()
+
+        self.assertEqual(Client.objects.filter(schema_name='case_test').count(), 1)
+
+    def test_tenants_that_already_collide_can_still_be_saved(self):
+        Client = get_tenant_model()
+        Client(schema_name='case_test').save()
+
+        # Simulate a database that already holds a colliding pair from before the
+        # check existed -- upgrading must not lock anyone out of their own tenant.
+        other = Client(schema_name='case_test_2')
+        other.save()
+        Client.objects.filter(pk=other.pk).update(schema_name='CASE_TEST')
+
+        other = Client.objects.get(pk=other.pk)
+        other.auto_create_schema = False
+        other.save()
+
+        self.assertEqual(Client.objects.filter(schema_name__iexact='case_test').count(), 2)
+
+    def test_schema_exists_is_case_sensitive_by_default(self):
+        Client = get_tenant_model()
+        Client(schema_name='case_test').save()
+
+        # PostgreSQL created "case_test", not "CASE_TEST" -- they are distinct
+        # schemas, so the default comparison must not conflate them.
+        self.assertTrue(schema_exists('case_test'))
+        self.assertFalse(schema_exists('CASE_TEST'))
+        self.assertTrue(schema_exists('CASE_TEST', case_sensitive=False))
+
+    def test_rename_schema_to_name_differing_only_in_case_is_rejected(self):
+        Client = get_tenant_model()
+        tenant = Client(schema_name='case_test')
+        tenant.save()
+
+        with self.assertRaisesRegex(ValidationError, 'New schema name already exists'):
+            schema_rename(tenant=Client.objects.filter(pk=tenant.pk).first(),
+                          new_schema_name='CASE_TEST')
+
+        self.assertTrue(schema_exists('case_test'))
 
 
 class CloneSchemaTest(BaseTestCase):

--- a/django_tenants/utils.py
+++ b/django_tenants/utils.py
@@ -190,12 +190,24 @@ def django_is_in_test_mode():
     return hasattr(mail, 'outbox')
 
 
-def schema_exists(schema_name, database=get_tenant_database_alias()):
+def schema_exists(schema_name, database=get_tenant_database_alias(), case_sensitive=True):
+    """
+    Checks whether `schema_name` exists in the database.
+
+    PostgreSQL schema names are case sensitive -- `CREATE SCHEMA "C2"` and
+    `CREATE SCHEMA "c2"` create two distinct schemas -- so the comparison is
+    exact by default. Pass `case_sensitive=False` to ask the different question
+    of whether any schema would collide with `schema_name` ignoring case, which
+    is what the tenant uniqueness checks need. See #846.
+    """
     _connection = connections[database]
     cursor = _connection.cursor()
 
     # check if this schema already exists in the db
-    sql = 'SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_namespace WHERE LOWER(nspname) = LOWER(%s))'
+    if case_sensitive:
+        sql = 'SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = %s)'
+    else:
+        sql = 'SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_namespace WHERE LOWER(nspname) = LOWER(%s))'
     cursor.execute(sql, (schema_name, ))
 
     row = cursor.fetchone()
@@ -217,7 +229,9 @@ def schema_rename(tenant, new_schema_name, database=get_tenant_database_alias(),
     _connection = connections[database]
     cursor = _connection.cursor()
 
-    if schema_exists(new_schema_name):
+    # A name differing only in case collides too -- django-tenants treats such
+    # names as the same tenant, so renaming 'c2' to 'C2' is refused. #846
+    if schema_exists(new_schema_name, database=database, case_sensitive=False):
         raise ValidationError("New schema name already exists")
     if not is_valid_schema_name(new_schema_name):
         raise ValidationError("Invalid string used for the schema name.")

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -43,6 +43,11 @@ Now we can create our first real tenant.
     domain.is_primary = True
     domain.save()
 
+Schema names may contain upper case characters, but two tenants whose schema names differ only in
+case are not allowed -- creating a tenant ``Tenant1`` when ``tenant1`` already exists raises a
+``ValidationError``. PostgreSQL would treat those as two separate schemas, while django-tenants
+treats the names as the same tenant, so allowing both leaves two tenants fighting over one schema.
+
 Because you have the tenant middleware installed, any request made to ``tenant.my-domain.com`` will now automatically set your PostgreSQL's ``search_path`` to ``tenant1, public``, making shared apps available too. The tenant will be made available at ``request.tenant``. By the way, the current schema is also available at ``connection.schema_name``, which is useful, for example, if you want to hook to any of django's signals.
 
 Any call to the methods ``filter``, ``get``, ``save``, ``delete`` or any other function involving a database connection will now be done at the tenant's schema, so you shouldn't need to change anything at your views.


### PR DESCRIPTION
Fixes #846.

## Problem

`schema_exists()` compared names case-insensitively (`LOWER(nspname) = LOWER(%s)`, unchanged since the 2015 rename from django-tenant-schemas), while `CREATE SCHEMA "%s"`, `DROP SCHEMA "%s"` and the search path are all case-sensitive.

So with `c2` already present, creating tenant `C2`:

1. The unique constraint on `schema_name` is case-sensitive in PostgreSQL, so the row inserted cleanly.
2. `create_schema(check_if_exists=True)` → `schema_exists("C2")` matched `c2` → returned early, so **the schema was never created**.
3. `save()` ignores that return value and still fired `post_schema_sync`, so the tenant looked fine.
4. PostgreSQL does not validate `search_path` at `SET` time and silently ignores schemas that don't exist, so `SET search_path = 'C2','public'` left the tenant resolving to **`public` only**.

That produced the duplicate `django_migrations` table in the report, but the same path means every query for that tenant read and wrote the public schema.

## Fix

- `schema_exists()` takes `case_sensitive` (default `True`) and compares exactly, so a case-differing schema no longer suppresses creation.
- `TenantMixin` rejects a new tenant whose schema name matches an existing one ignoring case. The check is in `save()` rather than `_check_schema_name()`, which runs for every search path element on every schema switch.
- `schema_rename()` and `CloneSchema.clone_schema()` are asking the collision question, so they pass `case_sensitive=False`. `schema_rename()` also no longer ignores its own `database` argument when checking.

The issue suggests making `PGSQL_VALID_SCHEMA_NAME` reject upper case. That would break `test_validation_utils.py::test_check_schema_name_upper_case_is_valid`, and because `_check_schema_name` runs on every search path element, existing installs with a mixed-case schema would raise on every request. Mixed case stays valid here; only the collision is refused.

## Upgrade notes

The check only runs when adding a tenant, so installs that already hold a colliding pair can still save those rows instead of being locked out. For such an install, the first save of the broken tenant now creates and migrates its real schema (via the existing `not schema_exists(...)` branch in `save()`) — that is the repair, but data already written into `public` stays there.

## Testing

5 new tests in `TenantSchemaNameCaseTest`; 2 of them fail on the unpatched code. Full suite run under both the `standard` and `multiprocessing` executors against PostgreSQL 16, plus the `create_tenant`/`clone_tenant` integration steps from `run_tests.sh`.

The one failure throughout, `test_deprecated_module_raises_warning`, is pre-existing and unrelated — it fails on a clean checkout of master too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)