### PR TITLE
Make delete_tenant honour a "yes" at the first prompt (#1058)

### DIFF
--- a/django_tenants/management/commands/delete_tenant.py
+++ b/django_tenants/management/commands/delete_tenant.py
@@ -29,15 +29,15 @@ class Command(InteractiveTenantOption, BaseCommand):
         schema_name = tenant.schema_name
         if options["interactive"]:
             self.print_warning(f"Warning you are about to delete '{schema_name}' there is no undo.")
-            result = input(f"Are you sure you want to delete '{schema_name}'?")
-            while len(result) < 1 or result.lower() not in ["yes", "no"]:
+            result = input(f"Are you sure you want to delete '{schema_name}' [yes/no]? ")
+            while result.lower() not in ["yes", "no"]:
                 result = input("Please answer yes or no: ")
-                if result.lower() == "yes":
-                    self.delete_tenant(tenant)
-                elif result.lower() == "no":
-                    self.stderr.write("Canceled")
-        else:
-            self.delete_tenant(tenant)
+
+            if result.lower() == "no":
+                self.stderr.write("Canceled")
+                return
+
+        self.delete_tenant(tenant)
 
     def delete_tenant(self, tenant):
         self.print_info(f"Deleting '{tenant.schema_name}'" )

--- a/django_tenants/tests/test_commands.py
+++ b/django_tenants/tests/test_commands.py
@@ -1,9 +1,12 @@
 import io
 import json
+from unittest import mock
 
 from django.core.management import call_command
 
 from django_tenants.test.cases import FastTenantTestCase
+from django_tenants.tests.testcases import BaseTestCase
+from django_tenants.utils import get_tenant_model, schema_exists
 from dts_test_app.models import DummyModel
 
 
@@ -45,3 +48,53 @@ class TenantCommandTestCase(FastTenantTestCase):
             out.getvalue(),  # test that stdout is passed
             indented_dump_data  # test that indent is passed
         )
+
+
+class DeleteTenantCommandTestCase(BaseTestCase):
+    """
+    Confirming the prompt has to actually delete the tenant. #1058
+    """
+
+    def create_tenant(self, schema_name='delete_test'):
+        tenant = get_tenant_model()(schema_name=schema_name)
+        tenant.save()
+        self.assertTrue(schema_exists(schema_name))
+        return tenant
+
+    def test_answering_yes_at_the_first_prompt_deletes_the_tenant(self):
+        tenant = self.create_tenant()
+
+        with mock.patch('builtins.input', return_value='yes'):
+            call_command('delete_tenant', schema_name=tenant.schema_name, stderr=io.StringIO())
+
+        self.assertFalse(get_tenant_model().objects.filter(pk=tenant.pk).exists())
+        self.assertFalse(schema_exists(tenant.schema_name))
+
+    def test_answering_no_keeps_the_tenant(self):
+        tenant = self.create_tenant()
+        stderr = io.StringIO()
+
+        with mock.patch('builtins.input', return_value='no'):
+            call_command('delete_tenant', schema_name=tenant.schema_name, stderr=stderr)
+
+        self.assertIn('Canceled', stderr.getvalue())
+        self.assertTrue(get_tenant_model().objects.filter(pk=tenant.pk).exists())
+        self.assertTrue(schema_exists(tenant.schema_name))
+
+    def test_unrecognised_answer_is_reprompted_until_valid(self):
+        tenant = self.create_tenant()
+
+        with mock.patch('builtins.input', side_effect=['maybe', '', 'yes']) as mocked_input:
+            call_command('delete_tenant', schema_name=tenant.schema_name, stderr=io.StringIO())
+
+        self.assertEqual(mocked_input.call_count, 3)
+        self.assertFalse(schema_exists(tenant.schema_name))
+
+    def test_noinput_deletes_without_prompting(self):
+        tenant = self.create_tenant()
+
+        with mock.patch('builtins.input', side_effect=AssertionError('should not prompt')):
+            call_command('delete_tenant', schema_name=tenant.schema_name, interactive=False,
+                         stderr=io.StringIO())
+
+        self.assertFalse(schema_exists(tenant.schema_name))


### PR DESCRIPTION
Fixes #1058.

## Problem

The delete only happened inside the body of the answer-validation loop:

```python
result = input(f"Are you sure you want to delete '{schema_name}'?")
while len(result) < 1 or result.lower() not in ["yes", "no"]:
    result = input("Please answer yes or no: ")
    if result.lower() == "yes":
        self.delete_tenant(tenant)
    elif result.lower() == "no":
        self.stderr.write("Canceled")
```

Answering `yes` at the first prompt makes the loop condition false, so the body never runs and the command exits having deleted nothing and printed nothing — exactly what the screenshots in the issue show. Answering `no` was equally unreachable, and once inside the loop it never terminated on a valid answer: `no` wrote "Canceled" and then asked again.

## Fix

The loop now only normalises the answer, and the delete happens after it, so all three cases behave: `yes` deletes, `no` cancels and returns, anything else re-prompts. The prompt also spells out the accepted answers (`[yes/no]`).

## Testing

4 new tests in `DeleteTenantCommandTestCase` covering yes / no / re-prompt / `--noinput`, with `builtins.input` patched. The `yes` and `no` tests both fail on the unpatched code:

```
FAIL: test_answering_yes_at_the_first_prompt_deletes_the_tenant
AssertionError: True is not false
FAIL: test_answering_no_keeps_the_tenant
AssertionError: 'Canceled' not found in "...Warning you are about to delete 'delete_test'..."
```

Full suite run under both the `standard` and `multiprocessing` executors against PostgreSQL 16. The one failure, `test_deprecated_module_raises_warning`, is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)