### PR TITLE
Give all_tenants_command a handle() so call_command works (#627)

### DIFF
--- a/django_tenants/management/commands/all_tenants_command.py
+++ b/django_tenants/management/commands/all_tenants_command.py
@@ -1,7 +1,7 @@
-import argparse
+import sys
 
 from django.core.management.base import BaseCommand, CommandError
-from django.core.management import get_commands, load_command_class
+from django.core.management import call_command, get_commands, load_command_class
 from django.db import connection
 from django_tenants.utils import get_tenant_model, get_public_schema_name
 
@@ -12,45 +12,73 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         super().add_arguments(parser)
-           
+
         parser.add_argument('--no-public', nargs='?', const=True, default=False, help='Exclude the public schema')
         parser.add_argument('command_name', nargs='+', help='The command name you want to run')
+
+    def get_tenants(self, no_public):
+        tenants = get_tenant_model().objects.all()
+        if no_public:
+            tenants = tenants.exclude(schema_name=get_public_schema_name())
+        return tenants
+
+    def handle(self, *args, **options):
+        """
+        Runs the wrapped command on every tenant.
+
+        This is the path call_command() takes. The command line goes through
+        run_from_argv() instead, so that options belonging to the wrapped command
+        can be passed through without this command having to declare them. #627
+        """
+        command_name, *command_args = options['command_name']
+
+        if command_name not in get_commands():
+            raise CommandError("Unknown command: %r" % command_name)
+
+        for tenant in self.get_tenants(options['no_public']):
+            self.stdout.write("Applying command to: %s" % tenant.schema_name)
+            connection.set_tenant(tenant)
+            call_command(command_name, *command_args)
 
     def run_from_argv(self, argv):
         """
         Changes the option_list to use the options from the wrapped command.
         """
-        # load the command object.
-        if len(argv) <= 2:
-            return
-        
-        no_public = "--no-public" in argv
-        
-        command_args = [argv[0]]
-        
-        command_args.extend(argv[3:] if no_public else argv[2:])
-        
         try:
-            app_name = get_commands()[command_args[1]]
+            self.run_wrapped_command_from_argv(argv)
+        except CommandError as e:
+            self.stderr.write("%s: %s" % (e.__class__.__name__, e))
+            sys.exit(1)
+
+    def run_wrapped_command_from_argv(self, argv):
+        original_argv = list(argv)
+
+        # --no-public is ours, so take it out wherever it appears -- what is left
+        # belongs to the wrapped command.
+        argv = list(argv)
+        no_public = "--no-public" in argv
+        if no_public:
+            argv.remove("--no-public")
+
+        if len(argv) <= 2 or argv[2] in ("-h", "--help"):
+            # There is no command to wrap, so hand back to Django's own parser to
+            # report the missing command name or print this command's help.
+            return super().run_from_argv(original_argv)
+
+        command_name = argv[2]
+
+        try:
+            app_name = get_commands()[command_name]
         except KeyError:
-            raise CommandError("Unknown command: %r" % command_args[1])
+            raise CommandError("Unknown command: %r" % command_name)
 
         if isinstance(app_name, BaseCommand):
             # if the command is already loaded, use it directly.
             klass = app_name
         else:
-            klass = load_command_class(app_name, command_args[1])
+            klass = load_command_class(app_name, command_name)
 
-        schema_parser = argparse.ArgumentParser()
-        schema_namespace, args = schema_parser.parse_known_args(command_args)
-        print(args)
-
-        tenant_model = get_tenant_model()
-        tenants = tenant_model.objects.all()
-        if no_public:
-            tenants = tenants.exclude(schema_name=get_public_schema_name())
-        for tenant in tenants:
+        for tenant in self.get_tenants(no_public):
             self.stdout.write("Applying command to: %s" % tenant.schema_name)
             connection.set_tenant(tenant)
-            klass.run_from_argv(args)
-
+            klass.run_from_argv([argv[0], command_name] + argv[3:])

--- a/django_tenants/tests/test_commands.py
+++ b/django_tenants/tests/test_commands.py
@@ -1,11 +1,13 @@
+import contextlib
 import io
 import json
 from unittest import mock
 
 from django.core.management import call_command
-from django.core.management.base import CommandError
+from django.core.management.base import BaseCommand, CommandError, OutputWrapper
 from django.db import connection
 
+from django_tenants.management.commands.all_tenants_command import Command as AllTenantsCommand
 from django_tenants.test.cases import FastTenantTestCase
 from django_tenants.tests.testcases import BaseTestCase
 from django_tenants.utils import get_tenant_model, get_public_schema_name
@@ -122,3 +124,84 @@ class AllTenantsCommandTestCase(BaseTestCase):
     def test_unknown_command_raises_command_error(self):
         with self.assertRaisesRegex(CommandError, 'Unknown command'):
             call_command('all_tenants_command', 'no_such_command', stdout=io.StringIO())
+
+    # The command line goes through run_from_argv() rather than handle(), so it
+    # needs driving separately from the call_command() tests above.
+
+    def run_from_argv(self, *args):
+        """
+        Runs the command the way manage.py does, capturing its own output.
+        """
+        command = AllTenantsCommand()
+        stdout, stderr = io.StringIO(), io.StringIO()
+        command.stdout, command.stderr = OutputWrapper(stdout), OutputWrapper(stderr)
+        command.run_from_argv(['manage.py', 'all_tenants_command', *args])
+        return stdout.getvalue(), stderr.getvalue()
+
+    @staticmethod
+    def wrapped_command(calls):
+        """
+        Stands in for the wrapped command class that run_from_argv() loads.
+        """
+        class Wrapped(BaseCommand):
+            def run_from_argv(self, argv):
+                calls.append((argv, connection.schema_name))
+
+        return Wrapped()
+
+    def test_command_line_runs_the_wrapped_command_on_every_tenant(self):
+        calls = []
+
+        with mock.patch('django_tenants.management.commands.all_tenants_command.load_command_class',
+                        return_value=self.wrapped_command(calls)):
+            self.run_from_argv('dumpdata', '--indent=4')
+
+        self.assertCountEqual([schema for _, schema in calls],
+                              [get_public_schema_name(), 'all_tenants_test'])
+        # The wrapped command's own options are handed straight through.
+        for argv, _ in calls:
+            self.assertEqual(argv, ['manage.py', 'dumpdata', '--indent=4'])
+
+    def test_command_line_no_public_is_stripped_from_anywhere(self):
+        calls = []
+
+        with mock.patch('django_tenants.management.commands.all_tenants_command.load_command_class',
+                        return_value=self.wrapped_command(calls)):
+            self.run_from_argv('dumpdata', '--no-public', 'dts_test_app.DummyModel')
+
+        self.assertEqual([schema for _, schema in calls], ['all_tenants_test'])
+        self.assertEqual(calls[0][0], ['manage.py', 'dumpdata', 'dts_test_app.DummyModel'])
+
+    def test_command_line_uses_an_already_loaded_command(self):
+        calls = []
+        loaded = self.wrapped_command(calls)
+
+        # get_commands() hands back a BaseCommand instance rather than an app
+        # label when a command is already loaded.
+        with mock.patch('django_tenants.management.commands.all_tenants_command.get_commands',
+                        return_value={'preloaded': loaded}):
+            self.run_from_argv('preloaded')
+
+        self.assertEqual(len(calls), 2)
+
+    def test_command_line_unknown_command_exits_non_zero(self):
+        with self.assertRaises(SystemExit) as raised:
+            _, stderr = self.run_from_argv('no_such_command')
+
+        self.assertEqual(raised.exception.code, 1)
+
+    def test_command_line_without_a_command_name_reports_usage(self):
+        # Falls back to Django's parser, which exits 2 on a missing argument.
+        with self.assertRaises(SystemExit) as raised:
+            with contextlib.redirect_stderr(io.StringIO()):
+                self.run_from_argv()
+
+        self.assertEqual(raised.exception.code, 2)
+
+    def test_command_line_help_is_not_treated_as_a_command_name(self):
+        with self.assertRaises(SystemExit) as raised:
+            with contextlib.redirect_stdout(io.StringIO()) as help_text:
+                self.run_from_argv('--help')
+
+        self.assertEqual(raised.exception.code, 0)
+        self.assertIn('--no-public', help_text.getvalue())

--- a/django_tenants/tests/test_commands.py
+++ b/django_tenants/tests/test_commands.py
@@ -1,9 +1,14 @@
 import io
 import json
+from unittest import mock
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.db import connection
 
 from django_tenants.test.cases import FastTenantTestCase
+from django_tenants.tests.testcases import BaseTestCase
+from django_tenants.utils import get_tenant_model, get_public_schema_name
 from dts_test_app.models import DummyModel
 
 
@@ -45,3 +50,75 @@ class TenantCommandTestCase(FastTenantTestCase):
             out.getvalue(),  # test that stdout is passed
             indented_dump_data  # test that indent is passed
         )
+
+
+class AllTenantsCommandTestCase(BaseTestCase):
+    """
+    all_tenants_command is documented but had no handle(), so every
+    call_command() of it raised NotImplementedError. #627
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sync_shared()
+
+    def setUp(self):
+        super().setUp()
+        # TransactionTestCase flushes rows between tests, so build the tenants
+        # each time rather than once for the class.
+        self.public_tenant = get_tenant_model().objects.create(schema_name=get_public_schema_name())
+        self.tenant = get_tenant_model().objects.create(schema_name='all_tenants_test')
+
+    def tearDown(self):
+        connection.set_schema_to_public()
+        self.tenant.delete(force_drop=True)
+        # Only the row -- dropping the public schema would take the shared tables
+        # with it. auto_drop_schema is set explicitly because other test cases
+        # flip it on the model class.
+        self.public_tenant.auto_drop_schema = False
+        self.public_tenant.delete()
+        super().tearDown()
+
+    @staticmethod
+    def record_schemas():
+        """
+        Stands in for the wrapped command, noting the schema it was run under.
+        """
+        schemas = []
+
+        def wrapped(*args, **kwargs):
+            schemas.append(connection.schema_name)
+
+        return schemas, mock.patch(
+            'django_tenants.management.commands.all_tenants_command.call_command',
+            side_effect=wrapped,
+        )
+
+    def test_call_command_runs_the_wrapped_command_on_every_tenant(self):
+        schemas, patched = self.record_schemas()
+
+        with patched:
+            call_command('all_tenants_command', 'check', stdout=io.StringIO())
+
+        self.assertCountEqual(schemas, [get_public_schema_name(), 'all_tenants_test'])
+
+    def test_no_public_excludes_the_public_schema(self):
+        schemas, patched = self.record_schemas()
+
+        with patched:
+            call_command('all_tenants_command', 'check', no_public=True, stdout=io.StringIO())
+
+        self.assertEqual(schemas, ['all_tenants_test'])
+
+    def test_arguments_are_passed_to_the_wrapped_command(self):
+        with mock.patch('django_tenants.management.commands.all_tenants_command.call_command') as mocked:
+            call_command('all_tenants_command', 'dumpdata', 'dts_test_app.DummyModel', stdout=io.StringIO())
+
+        self.assertEqual(mocked.call_count, 2)
+        for call in mocked.call_args_list:
+            self.assertEqual(call.args, ('dumpdata', 'dts_test_app.DummyModel'))
+
+    def test_unknown_command_raises_command_error(self):
+        with self.assertRaisesRegex(CommandError, 'Unknown command'):
+            call_command('all_tenants_command', 'no_such_command', stdout=io.StringIO())

--- a/docs/use.rst
+++ b/docs/use.rst
@@ -486,6 +486,20 @@ If the command you need to run on all tenants should not be run on the public te
 
     ./manage.py all_tenants_command --no-public loaddata
 
+It can also be called from Python:
+
+.. code-block:: python
+
+    from django.core.management import call_command
+
+    call_command('all_tenants_command', 'loaddata', 'fixture.json')
+    call_command('all_tenants_command', 'loaddata', 'fixture.json', no_public=True)
+
+Options belonging to the wrapped command, such as ``--indent=4``, can only be given on the command
+line -- ``call_command`` validates its keyword arguments against ``all_tenants_command`` itself, so
+it rejects any option that command does not declare. Pass positional arguments as above, or use
+``call_command`` on the wrapped command inside ``tenant_context()`` if you need its options.
+
 
 
 create_tenant_superuser


### PR DESCRIPTION
Fixes #627.

## Problem

`all_tenants_command` only overrode `run_from_argv`, so anything reaching it through `call_command()` fell through to `BaseCommand.handle` and raised `NotImplementedError`. It is documented in `docs/use.rst` but had no test coverage.

Three further defects in the same file:

- `--no-public` was assumed to sit immediately after the command name (`argv[3:] if no_public else argv[2:]`), so `all_tenants_command dumpdata --no-public x` reported ``Unknown command: '--no-public'``.
- Invoking with no command name hit `if len(argv) <= 2: return` and silently did nothing. `--help` was treated as the command name and died with ``Unknown command: '--help'``.
- A leftover `print(args)` debug statement, and an `argparse.ArgumentParser()` round trip that only ever echoed its own input back.

## Fix

- Add `handle()`, which runs the wrapped command on every tenant. The command line still goes through `run_from_argv()` so options belonging to the wrapped command need not be declared here.
- Strip `--no-public` wherever it appears; what is left belongs to the wrapped command.
- No command name and `--help` hand back to Django's parser, which reports the missing argument (exit 2) or prints usage (exit 0).
- Drop the debug `print()` and the argparse round trip.

## Note on `call_command` options

`call_command` validates keyword arguments against `all_tenants_command`'s own parser, so the *wrapped* command's flags (`--indent=4`) can only be given on the command line. Positional arguments work either way. Documented in `docs/use.rst`.

## Testing

4 new tests in `AllTenantsCommandTestCase`. All four error with the issue's exact `NotImplementedError: subclasses of BaseCommand must provide a handle() method` on the unpatched code.

Since the tests exercise `handle()`, I also checked the rewritten CLI path by hand against a real database — passthrough with a flag, `--no-public` both before and after the command name, unknown command, missing command name, and `--help`.

Full suite run under both the `standard` and `multiprocessing` executors against PostgreSQL 16. The one failure, `test_deprecated_module_raises_warning`, is pre-existing and unrelated.

## Merge order

Conflicts with #1252 in `django_tenants/tests/test_commands.py` — one import line to union, plus both test classes appended at the same spot. Merging this one second makes it a trivial resolution; I have verified the merged result is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)