### PR TITLE
Test PostgreSQL 14 against the newest Django that supports it

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -10,7 +10,9 @@ jobs:
     name: Postgres compatibility ${{ matrix.postgres-version }}
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      # one unsupported server should not cancel the others, or a single old
+      # version going out of support hides the results for every newer one
+      fail-fast: false
       matrix: # https://www.postgresql.org/docs/release
         # always use latest Python b/c the point here is to test PostgreSQL compatibility
         python-version: ["3.13"]
@@ -26,8 +28,15 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        # always use latest Django b/c the point here is to test PostgreSQL compatibility
-        pip install Django
+        # always use latest Django b/c the point here is to test PostgreSQL
+        # compatibility -- except that each Django series drops the servers it no
+        # longer supports, so an older server gets the newest series that still
+        # takes it. Django 6.1 requires PostgreSQL 15 or later.
+        if [ "${{ matrix.postgres-version }}" -lt 15 ]; then
+          pip install "Django<6.1"
+        else
+          pip install Django
+        fi
         pip install -e ".[dev]"
 
     - name: Create database


### PR DESCRIPTION
Fixes the red `Postgres compatibility 14` job on master.

## What broke

Django 6.1 was released to PyPI on 5 August 2026 at 19:21 UTC and **requires PostgreSQL 15 or later**. The `postgres_compatibility` job installs Django unpinned, deliberately — the point of that job is the server version, not the Django version — so the moment 6.1 became `latest`, the PostgreSQL 14 entry began failing at connection setup:

```
django.db.utils.NotSupportedError: PostgreSQL 15 or later is required (found 14.23).
```

That is raised in `check_database_version_supported` before any project code runs. Nothing in the repository changed: master's run at 16:19 resolved Django 6.0.8 and passed, the run at 20:26 resolved 6.1 and failed. Confirmed by checking out `ba42724` (the v3.14.0 release commit) and running it against PostgreSQL 14 with Django 6.1 — identical error.

## What this changes

- **PostgreSQL 14 gets the newest Django series that still supports it** (`Django<6.1`). django-tenants supports Django 5.2, which supports PostgreSQL 14, so the server is still worth covering rather than dropping. When a future series drops 15, the same conditional extends.
- **`fail-fast: false` on that matrix.** PostgreSQL 14 going out of support cancelled 15, 16 and 17, so a single unsupported combination left no results at all for the versions that do matter.

## Testing

Locally, mirroring the job's steps with `./run_tests.sh`:

| Server | Django | Result |
|---|---|---|
| 14.23 | 6.0.8 (pinned path) | exit 0 — 139 tests × 2 executors + integration |
| 17.10 | 6.1 (unpinned path) | exit 0 — 139 tests × 2 executors + integration |

The PostgreSQL 17 + Django 6.1 combination had never actually run in CI, since `fail-fast` cancelled it every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)